### PR TITLE
feat: thread inner_etype + polish through ifoffload_eig helpers

### DIFF
--- a/src/boundary_algorithm/vumps/general.jl
+++ b/src/boundary_algorithm/vumps/general.jl
@@ -25,17 +25,41 @@ permute_fronttail(t::AbstractZero) = t
 # These accept the big neighbourhood tensors as explicit args so that
 # `checkpoint_offload` can move them to host memory during the backward
 # re-compute on GPU runs.
-function _simple_eig_FLmap(FLij, ALu_i, ALd_ir, M_i; power_iter, ifparallel, forloop_iter)
-    f(x) = FLmap(1, x, ALu_i, ALd_ir, M_i; ifparallel, forloop_iter)
-    return simple_eig(f, FLij; power_iter)
+#
+# Mixed-precision + polish support: the helpers thread `inner_etype` into
+# the underlying map call, and if `final_polish_steps > 0` they construct
+# an `f_final` that promotes back to full precision for the last N power
+# iterations — mirroring the non-offload `polish_fine` branch in leftenv /
+# rightenv / ACenv below.
+function _simple_eig_FLmap(FLij, ALu_i, ALd_ir, M_i; power_iter, ifparallel, forloop_iter,
+                            inner_etype=nothing, final_polish_steps=0)
+    f(x) = FLmap(1, x, ALu_i, ALd_ir, M_i; ifparallel, forloop_iter, inner_etype)
+    if final_polish_steps > 0
+        f_final(x) = FLmap(1, x, ALu_i, ALd_ir, M_i; ifparallel, forloop_iter, inner_etype=nothing)
+        return simple_eig(f, FLij; power_iter, f_final, final_polish_steps)
+    else
+        return simple_eig(f, FLij; power_iter)
+    end
 end
-function _simple_eig_FRmap(FRiNj, ARu_i, ARd_ir, M_i, Nj; power_iter, ifparallel, forloop_iter)
-    f(x) = FRmap(Nj, x, ARu_i, ARd_ir, M_i; ifparallel, forloop_iter)
-    return simple_eig(f, FRiNj; power_iter)
+function _simple_eig_FRmap(FRiNj, ARu_i, ARd_ir, M_i, Nj; power_iter, ifparallel, forloop_iter,
+                            inner_etype=nothing, final_polish_steps=0)
+    f(x) = FRmap(Nj, x, ARu_i, ARd_ir, M_i; ifparallel, forloop_iter, inner_etype)
+    if final_polish_steps > 0
+        f_final(x) = FRmap(Nj, x, ARu_i, ARd_ir, M_i; ifparallel, forloop_iter, inner_etype=nothing)
+        return simple_eig(f, FRiNj; power_iter, f_final, final_polish_steps)
+    else
+        return simple_eig(f, FRiNj; power_iter)
+    end
 end
-function _simple_eig_ACmap(AC1j, FL_j, FR_j, M_j; power_iter, ifparallel, forloop_iter)
-    f(x) = ACmap(1, x, FL_j, FR_j, M_j; ifparallel, forloop_iter)
-    return simple_eig(f, AC1j; power_iter)
+function _simple_eig_ACmap(AC1j, FL_j, FR_j, M_j; power_iter, ifparallel, forloop_iter,
+                            inner_etype=nothing, final_polish_steps=0)
+    f(x) = ACmap(1, x, FL_j, FR_j, M_j; ifparallel, forloop_iter, inner_etype)
+    if final_polish_steps > 0
+        f_final(x) = ACmap(1, x, FL_j, FR_j, M_j; ifparallel, forloop_iter, inner_etype=nothing)
+        return simple_eig(f, AC1j; power_iter, f_final, final_polish_steps)
+    else
+        return simple_eig(f, AC1j; power_iter)
+    end
 end
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -236,10 +260,11 @@ function leftenv(ALu, ALd, M, FL=FLint(ALu, M); ifobs=false, alg, kwargs...)
             f(FLij) = ifcheckpoint ? checkpoint(FLmap, 1, FLij, ALu[i, :], ALd[ir, :], M[i, :]; ifparallel, forloop_iter, inner_etype) : FLmap(1, FLij, ALu[i, :], ALd[ir, :], M[i, :]; ifparallel, forloop_iter, inner_etype)
             f_polish(FLij) = ifcheckpoint ? checkpoint(FLmap, 1, FLij, ALu[i, :], ALd[ir, :], M[i, :]; ifparallel, forloop_iter, inner_etype=nothing) : FLmap(1, FLij, ALu[i, :], ALd[ir, :], M[i, :]; ifparallel, forloop_iter, inner_etype=nothing)
             if alg.ifsimple_eig
-                # NOTE: ifoffload_eig is mutually exclusive with polish_fine and inner_etype
-                # (the `_simple_eig_FLmap` helper doesn't thread those kwargs through).
                 if alg.ifoffload_eig
-                    λLs, FLi1s = checkpoint_offload(_simple_eig_FLmap, FL[i, 1], ALu[i, :], ALd[ir, :], M[i, :]; power_iter, ifparallel, forloop_iter)
+                    λLs, FLi1s = checkpoint_offload(_simple_eig_FLmap, FL[i, 1], ALu[i, :], ALd[ir, :], M[i, :];
+                                                     power_iter, ifparallel, forloop_iter,
+                                                     inner_etype,
+                                                     final_polish_steps = polish_fine ? simple_eig_polish_steps : 0)
                 elseif polish_fine
                     λLs, FLi1s = simple_eig(f, FL[i, 1]; power_iter, f_final=f_polish, final_polish_steps=simple_eig_polish_steps)
                 else
@@ -307,7 +332,10 @@ function rightenv(ARu, ARd, M, FR=FRint(ARu, M); ifobs=false, alg, kwargs...)
             f_polish(FRiNj) = ifcheckpoint ? checkpoint(FRmap, Nj, FRiNj, ARu[i, :], ARd[ir, :], M[i, :]; ifparallel, forloop_iter, inner_etype=nothing) : FRmap(Nj, FRiNj, ARu[i, :], ARd[ir, :], M[i, :]; ifparallel, forloop_iter, inner_etype=nothing)
             if alg.ifsimple_eig
                 if alg.ifoffload_eig
-                    λRs, FR1s = checkpoint_offload(_simple_eig_FRmap, FR[i, Nj], ARu[i, :], ARd[ir, :], M[i, :], Nj; power_iter, ifparallel, forloop_iter)
+                    λRs, FR1s = checkpoint_offload(_simple_eig_FRmap, FR[i, Nj], ARu[i, :], ARd[ir, :], M[i, :], Nj;
+                                                    power_iter, ifparallel, forloop_iter,
+                                                    inner_etype,
+                                                    final_polish_steps = polish_fine ? simple_eig_polish_steps : 0)
                 elseif polish_fine
                     λRs, FR1s = simple_eig(f, FR[i, Nj]; power_iter, f_final=f_polish, final_polish_steps=simple_eig_polish_steps)
                 else
@@ -495,7 +523,10 @@ function ACenv(AC, FL, M, FR; alg, kwargs...)
             f_polish(AC1j) = ifcheckpoint ? checkpoint(ACmap, 1, AC1j, FL[:, j], FR[:, j], M[:, j]; ifparallel, forloop_iter, inner_etype=nothing) : ACmap(1, AC1j, FL[:, j], FR[:, j], M[:, j]; ifparallel, forloop_iter, inner_etype=nothing)
             if alg.ifsimple_eig
                 if alg.ifoffload_eig
-                    λACs, ACs = checkpoint_offload(_simple_eig_ACmap, AC[1, j], FL[:, j], FR[:, j], M[:, j]; power_iter, ifparallel, forloop_iter)
+                    λACs, ACs = checkpoint_offload(_simple_eig_ACmap, AC[1, j], FL[:, j], FR[:, j], M[:, j];
+                                                    power_iter, ifparallel, forloop_iter,
+                                                    inner_etype,
+                                                    final_polish_steps = polish_fine ? simple_eig_polish_steps : 0)
                 elseif polish_fine
                     λACs, ACs = simple_eig(f, AC[1, j]; power_iter, f_final=f_polish, final_polish_steps=simple_eig_polish_steps)
                 else


### PR DESCRIPTION
Follow-up to #35.  The previous PR merged before this commit was pushed; this PR brings it in.

## What changed (commit 88ffcd9)

Extends the three `_simple_eig_{FL,FR,AC}map` helpers with `inner_etype` and `final_polish_steps` kwargs.  When `final_polish_steps > 0` the helper builds an `f_final(x) = FLmap(...; inner_etype=nothing)` internally and calls `simple_eig(f, v; power_iter, f_final, final_polish_steps)` — mirroring the existing non-offload `polish_fine` branch.

Call sites in `leftenv` / `rightenv` / `ACenv` forward `inner_etype` and `polish_fine ? simple_eig_polish_steps : 0` when `ifoffload_eig=true`, so mixed-precision VUMPS + polish now composes cleanly with `ifoffload_eig`.

## Verified (RTX 4090)

Extended the gradient-equivalence smoke test against the baseline `ifcheckpoint` path:

| Group | case | ΔE vs baseline | Δg/\|g\| |
|---|---|---|---|
| A plain precision | `ifoffload_step=true` | +2.2e-16 | 1.8e-09 |
| A plain precision | `ifoffload_eig=true` | -1.1e-16 | 1.9e-09 |
| A plain precision | both | +3.3e-16 | 4.1e-10 |
| B mixed-precision (Float32 + polish=1) | `mp + ifoffload_eig=true` | -1.4e-12 | 9.0e-07 |
| B mixed-precision (Float32 + polish=1) | `mp + both` | -2.1e-12 | 1.3e-06 |

Group B differences are at the Float32 noise floor (accumulation-order perturbations across the offload round-trip), not a correctness issue.

## Files

`src/boundary_algorithm/vumps/general.jl` only (+45 −14).