### PR TITLE
Comment out forloop_back debug print

### DIFF
--- a/src/autodiff/rules.jl
+++ b/src/autodiff/rules.jl
@@ -207,7 +207,7 @@ function ChainRulesCore.rrule(::typeof(forloop), f, args...; forloop_iter, N_in,
                     end
                 end
             end
-            println("  forloop_back: forloop=$forloop_iter bp=$(round(t_bp*1000,digits=1))ms split=$D_split→$(length(ranges))")
+            # println("  forloop_back: forloop=$forloop_iter bp=$(round(t_bp*1000,digits=1))ms split=$D_split→$(length(ranges))")
             return NoTangent(), NoTangent(), dargs...
         end
 


### PR DESCRIPTION
## Summary
- Comment out the `println` in the `forloop` rrule backward pass (`src/autodiff/rules.jl:210`) that writes profiling info to stdout on every backward iteration during optimization

## Motivation
This debug print pollutes stdout during optimization runs. It can be uncommented when profiling is needed.

## Test plan
- [ ] Verify optimization runs produce clean stdout output

🤖 Generated with [Claude Code](https://claude.com/claude-code)