### PR TITLE
fix: use iotype=IOStream for all JLD2 save/load (#38)

### DIFF
--- a/src/ipeps_optimize/init.jl
+++ b/src/ipeps_optimize/init.jl
@@ -31,7 +31,7 @@ function init_ipeps(; atype=Array, etype=Float64, No::Int=0, D::Int, χ::Int, pa
     if No != 0
         file = joinpath(params.folder, "D$(D)", "ipeps", "χ$(χ)", "No.$(No).jld2")
         @info "load ipeps from file: $file"
-        A = load(file, "bcipeps")
+        A = load(file, "bcipeps"; iotype=IOStream)
     else
         lattice = params.model.lattice
         d = Int(2*params.model.S + 1)
@@ -71,7 +71,7 @@ into a larger tensor (using SU parameterization for the existing part).
 """
 function init_ipeps_SU(; atype=Array, No, D::Int, D_new::Int, χ::Int, params::iPEPSOptimize)
     file = joinpath(params.folder, "D$(D)", "ipeps", "χ$(χ)", "No.$(No).jld2")
-    A = load(file, "bcipeps")
+    A = load(file, "bcipeps"; iotype=IOStream)
     d = size(A, 5)
     params.verbosity >= 2 && @info "load ipeps from $file"
 
@@ -101,7 +101,7 @@ tensor, filling the new entries with a small random perturbation of magnitude
 """
 function init_ipeps_perturbation(; atype=Array, No, D::Int, D_new::Int, χ::Int, ϵ=1e-1, params::iPEPSOptimize)
     file = joinpath(params.folder, "D$(D)", "ipeps", "χ$(χ)", "No.$(No).jld2")
-    A = load(file, "bcipeps")
+    A = load(file, "bcipeps"; iotype=IOStream)
     params.verbosity >= 2 && @info "load ipeps from $file"
 
     # Preserve the original tensor shape per bond dimension
@@ -121,7 +121,7 @@ end
 
 function init_ipeps_from_1x1(;atype = Array, etype=ComplexF64, No, pattern, χ::Int, D::Int, ϵ::Real=1e-1, infolder)
     file = joinpath(infolder, "D$(D)", "ipeps", "χ$(χ)", "No.$(No).jld2")
-    A = load(file, "bcipeps")
+    A = load(file, "bcipeps"; iotype=IOStream)
     @info "load ipeps from $file"
     d = size(A, 5)
     A′ = zeros(etype, D,D,D,D,d, length(unique(pattern)))

--- a/src/ipeps_optimize/optimize.jl
+++ b/src/ipeps_optimize/optimize.jl
@@ -112,7 +112,7 @@ function _finalize!(x, f, g, iter, rt, rt′, D, χ, params, t0, fδEierr)
     if params.save_every  != 0 && iter % params.save_every  == 0
         ipeps_dir = joinpath(folder0, "ipeps", "χ$χ")
         !ispath(ipeps_dir) && mkpath(ipeps_dir)
-        save(joinpath(ipeps_dir, "No.$(iter).jld2"), "bcipeps", Array(x))
+        save(joinpath(ipeps_dir, "No.$(iter).jld2"), "bcipeps", Array(x); iotype=IOStream)
     end
 
     if abs(fδEierr[2]) < 1e-12 || abs(fδEierr[4]) > 1e-8

--- a/src/patch/OptimKit_patch.jl
+++ b/src/patch/OptimKit_patch.jl
@@ -62,7 +62,7 @@ end
 # Save LBFGS state to file
 function save_lbfgs_state(alg, state::LBFGSState, filename::String="lbfgs_state.jld2")
     try
-        save(filename, "state", state)  
+        save(filename, "state", state; iotype=IOStream)
         alg.verbosity >= 2 && @info "LBFGS state saved to $filename"
         return true
     catch e
@@ -74,7 +74,7 @@ end
 # Load LBFGS state from file
 function load_lbfgs_state(alg, filename::String="lbfgs_state.jld2")
     try
-        state = load(filename, "state")
+        state = load(filename, "state"; iotype=IOStream)
         alg.verbosity >= 2 && @info "LBFGS state loaded from $filename"
         return state
     catch e

--- a/src/utils/io.jl
+++ b/src/utils/io.jl
@@ -2,12 +2,12 @@ function save_rt(folder, rt; file::String)
     p = joinpath(folder, file)
     rt_save = Array(rt)
     @info "save a $(typeof(rt)) environment to $p"
-    save(p, "rt", rt_save)
+    save(p, "rt", rt_save; iotype=IOStream)
 end
 
 function load_rt(folder, atype, ifparallelupdown=false; file::String)
     p = joinpath(folder, file)
-    rt = load(p, "rt")
+    rt = load(p, "rt"; iotype=IOStream)
     if ifparallelupdown
         rtup, rtdown = rt
         @sync begin


### PR DESCRIPTION
## Summary

- Adds `iotype=IOStream` to every `save` / `load` call that touches a `.jld2` file (env, iPEPS checkpoint, LBFGS state).
- Sidesteps JLD2's default `MmapIO`, which fails with `SystemError: msync: Invalid argument` on JSC Jupiter compute nodes (reproduced on node-local `/tmp` overlay, GPFS `$SCRATCH`, and GPFS `$PROJECT` alike). The login node's behavior masked this during development.

Closes #38.

## Verification

Measured on `jpbo-088-11` (Jupiter booster compute node), Apr 2026:

| object | FS | save | load |
|---|---|---|---|
| 1.38 GiB (D=6 χ=400 N=4) | `/tmp` | 1.50 s | 0.90 s |
| 1.38 GiB | `$SCRATCH` | 0.26 s | 0.51 s |
| 3.82 GiB (D=10 χ=400 N=4) | `$PROJECT` | 0.66 s | 0.70 s |

All roundtrips byte-equal. Default-`MmapIO` run on the same node fails `msync` on every size / every filesystem.

## Test plan

- [x] Compute-node roundtrip test (`save`/`load` with `iotype=IOStream`) on all three filesystems
- [x] Login-node micro-benchmark: IOStream matches or beats MmapIO (no regression)
- [ ] Next real iPEPS run on Jupiter should now produce `environment/χ*.jld2` and `ipeps/χ*/No.*.jld2` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)