### PR TITLE
Pack parallel gradient allreduces

### DIFF
--- a/src/autodiff/rules.jl
+++ b/src/autodiff/rules.jl
@@ -13,6 +13,7 @@
 # p2p collectives — pure data-movement primitives, no AD through them.
 @non_differentiable allgatherv_p2p!(buf, counts, comm)
 @non_differentiable allreduce_p2p!(buf, op, comm)
+@non_differentiable _allreduce_many_p2p!(items, comm)
 
 # patch since it's currently broken otherwise
 function ChainRulesCore.rrule(::typeof(Base.typed_hvcat), ::Type{T}, rows::Tuple{Vararg{Int}}, xs::S...) where {T,S}
@@ -318,19 +319,15 @@ function ChainRulesCore.rrule(::typeof(parallel), f, args...; forloop_iter, N_in
             allgatherv_p2p!(dargs_c[j], counts, comm)
         end
 
-        # 2) Allreduce non-split args via p2p with pre-allocated buffers
+        # 2) Allreduce non-split args in one packed p2p collective.
+        reduce_items = Any[]
         for j in 1:length(args_c)
             if j == N_in[1] && has_split_gather
                 continue
             end
-            if dargs_c[j] isa Tuple
-                for k in 1:length(dargs_c[j])
-                    allreduce_p2p!(dargs_c[j][k], +, comm)
-                end
-            else
-                allreduce_p2p!(dargs_c[j], +, comm)
-            end
+            _push_allreduce_items!(reduce_items, dargs_c[j])
         end
+        _allreduce_many_p2p!(Tuple(reduce_items), comm)
 
         # Upcast partial gradients back to original precision at boundary exit.
         dargs = do_cast ? ntuple(i -> args[i] isa Tuple ? map(x -> T_orig.(x), dargs_c[i]) : T_orig.(dargs_c[i]), length(args)) :

--- a/src/contraction/forloop_parallel_MPI.jl
+++ b/src/contraction/forloop_parallel_MPI.jl
@@ -26,6 +26,7 @@ end
 const _comm_sendbuf = Ref{Any}(nothing)
 const _comm_recvbuf = Ref{Any}(nothing)
 const _comm_hostbuf = Ref{Any}(nothing)   # CPU staging buf for host-staged Phase 2
+const _comm_packbuf = Ref{Any}(nothing)   # Packed multi-gradient allreduce buf
 const _comm_local = Ref{Any}(nothing)     # node-local communicator
 const _comm_leaders = Ref{Any}(nothing)   # inter-node leaders communicator
 const _comm_siblings = Ref{Any}(nothing)  # inter-node comm split by local_rank
@@ -48,6 +49,13 @@ function _ensure_buf!(ref, buf, n)
         ref[] = similar(buf, n)
     end
     return view(ref[], 1:n)
+end
+
+function _ensure_exact_buf!(ref, buf, n)
+    if isnothing(ref[]) || length(ref[]) != n || eltype(ref[]) != eltype(buf) || typeof(similar(ref[], 0)) != typeof(similar(buf, 0))
+        ref[] = similar(buf, n)
+    end
+    return ref[]
 end
 
 function _get_local_comm(comm)
@@ -343,6 +351,90 @@ function allreduce_p2p!(buf, ::typeof(+), comm)
     end
 
     return buf
+end
+
+function _push_allreduce_items!(flat, item)
+    if item isa Tuple
+        for x in item
+            _push_allreduce_items!(flat, x)
+        end
+    else
+        @assert item isa AbstractArray "_allreduce_many_p2p! only supports arrays and nested tuples of arrays"
+        push!(flat, item)
+    end
+    return flat
+end
+
+_allreduce_pack_key(item) = (eltype(item), typeof(similar(item, 0)))
+
+"""
+    _allreduce_many_p2p!(items, comm)
+
+Pack several gradient arrays into one contiguous buffer, run a single
+`allreduce_p2p!`, then unpack the reduced values back into the original arrays.
+This preserves the dense-gradient semantics while reducing the number of MPI
+Allreduce calls issued by `parallel`'s reverse pass.
+"""
+function _allreduce_many_p2p!(items, comm)
+    flat = Any[]
+    _push_allreduce_items!(flat, items)
+    isempty(flat) && return items
+
+    processed = falses(length(flat))
+    for seed in eachindex(flat)
+        processed[seed] && continue
+        key = _allreduce_pack_key(flat[seed])
+        group = Int[]
+        for i in eachindex(flat)
+            if !processed[i] && _allreduce_pack_key(flat[i]) == key
+                push!(group, i)
+                processed[i] = true
+            end
+        end
+        _allreduce_flat_group_p2p!(flat, group, comm)
+    end
+
+    return items
+end
+
+function _allreduce_flat_group_p2p!(flat, group, comm)
+    if length(group) == 1
+        allreduce_p2p!(flat[group[1]], +, comm)
+        return flat
+    end
+
+    first_item = flat[group[1]]
+    T = eltype(first_item)
+    for i in group
+        item = flat[i]
+        @assert eltype(item) == T "_allreduce_many_p2p! requires all packed arrays to have the same eltype"
+    end
+
+    total_len = sum(i -> length(flat[i]), group)
+    total_len == 0 && return flat
+
+    buf = _ensure_exact_buf!(_comm_packbuf, first_item, total_len)
+    offset = 0
+    for i in group
+        item = flat[i]
+        n = length(item)
+        n == 0 && continue
+        copyto!(view(buf, offset + 1:offset + n), reshape(item, :))
+        offset += n
+    end
+
+    allreduce_p2p!(buf, +, comm)
+
+    offset = 0
+    for i in group
+        item = flat[i]
+        n = length(item)
+        n == 0 && continue
+        copyto!(reshape(item, :), view(buf, offset + 1:offset + n))
+        offset += n
+    end
+
+    return flat
 end
 
 # Phase 2 helper: ring allreduce on a contiguous slice that every rank in

--- a/test/test_mpi.jl
+++ b/test/test_mpi.jl
@@ -77,4 +77,21 @@ using MPI
             @test all(Array(buf) .≈ T(sum(1:nprocs)))
         end
     end
+
+    @testset "packed allreduce correctness" begin
+        for atype in ATYPES, T in (Float64, ComplexF64)
+            a = atype(fill(T(rank + 1), 17))
+            b = atype(fill(T(10 * (rank + 1)), 3, 5))
+            c = atype(fill(T(100 * (rank + 1)), 2, 4, 3))
+
+            TeneT._allreduce_many_p2p!((a, b, c), comm)
+            CUDA.functional() && atype == CuArray && CUDA.synchronize()
+            MPI.Barrier(comm)
+
+            s = sum(1:nprocs)
+            @test all(Array(a) .≈ T(s))
+            @test all(Array(b) .≈ T(10s))
+            @test all(Array(c) .≈ T(100s))
+        end
+    end
 end


### PR DESCRIPTION
## Summary
- Add a packed allreduce helper that groups gradient arrays by eltype/backend and reduces each group through one `allreduce_p2p!` call.
- Use the packed helper in `parallel`'s reverse pass for non-split argument gradients, preserving dense-gradient semantics while reducing Allreduce launch count.
- Add optional MPI coverage for packed allreduce correctness.

## Test Plan
- [x] `packed allreduce 2-rank PASS` via `MPI.mpiexec() -n 2`
- [x] optional MPI single-process test file: `55/55 pass`
- [x] `FLmap_parallel` serial-vs-parallel gradient check: relative errors `(0.0, 0.0, 0.0, 0.0)`
- [x] manual one-step C4v VUMPS trace: PASS