### PR TITLE
feat(vumps): store distributed FR in runtime

### DIFF
--- a/docs/2026-05-08-distributed-FR-in-ACenv-design.md
+++ b/docs/2026-05-08-distributed-FR-in-ACenv-design.md
@@ -1,0 +1,90 @@
+# Distributed FR in VUMPS Runtime
+
+## Problem
+
+In `ACmap_parallel`, each GPU stores the full FR tensor but only uses its local
+slice (split on the last dimension). Peak memory includes a redundant
+`(1 - 1/nprocs)` fraction of FR per GPU — not just during ACenv's eigensolver,
+but for the entire VUMPS iteration since `VUMPSRuntime` stores FR.
+
+## Design
+
+Store only the local FR slice in `VUMPSRuntime`. Each `vumps_step` allgathers
+FR once at the start (for `rightenv` and `Cenv`), then prescatters the updated
+FR before `ACenv` and stores the distributed version back in the runtime.
+
+### Contraction analysis (leg4 case)
+
+```
+result[f,g,h] := AC[a,b,c] * FR[c,e,h] * M[d,g,e,b] * FL[a,d,f]
+```
+
+| Tensor | Per-GPU need | Reason |
+|--------|-------------|--------|
+| FR     | **slice only** (h_slice) | h is the parallelized free index |
+| FL     | full | f is free, a/d contracted across all values |
+| AC     | full | a/b/c all contracted |
+| M      | full | d/g/e/b contracted or free |
+
+### Changes
+
+1. **`prescatter_for_parallel` / `allgather_for_parallel`** in
+   `forloop_parallel_MPI.jl` — scatter/gather a single tensor along `split_dim`.
+   Each has a custom rrule in `rules.jl`.
+
+2. **`parallel()` in forloop_parallel_MPI.jl** — `input_prescattered::Bool` kwarg.
+   When true, `args[N_in[1]]` is already the local portion for this rank.
+
+3. **`ACmap_parallel` / `ACmap(I::Int, ...)`** — thread `fr_distributed` kwarg
+   through to `parallel(...; input_prescattered=true)`.
+
+4. **`_prescatter_FR` / `_allgather_FR`** in `general.jl` — StructArray-level
+   helpers that apply prescatter/allgather to each unique data tensor.
+
+5. **`vumps_step` / `vumps_step_power`** — allgather FR at start, run rightenv
+   and Cenv with full FR, prescatter FR, run ACenv with distributed FR, store
+   distributed FR in returned runtime.  Cenv is reordered before ACenv.
+
+6. **`init_VUMPSRuntime`** — prescatter FR after `rightenv` when `ifparallel`.
+
+7. **`ACenv()`** — accepts `fr_distributed` kwarg from caller; no longer
+   prescatters internally.
+
+8. **`ObsEnv()`** — allgathers FR before rightenv and VUMPSEnv construction.
+
+9. **`_simple_eig_ACmap`** — threads `fr_distributed` to ACmap closures.
+
+### Unchanged
+
+- `simple_eig()` (operates on full, allgathered AC)
+- `rightenv()` / `FRmap` (produces full FR as before)
+- `Cenv()` / `Cmap()` (uses full FR from allgather)
+- `leftenv()` / `FLmap`
+- Serial path (`ifparallel=false`)
+- Plaquette / C4v variants (use FL on both sides, no FR)
+- `VUMPSRuntime` struct (untyped `FR::StructArray` — shape change is transparent)
+
+### Communication cost
+
+One extra `allgatherv` per `vumps_step` (to reconstruct full FR for rightenv/Cenv).
+This is a single collective per step — negligible relative to the eigensolver work.
+
+### Memory savings
+
+Per GPU, persistent (entire VUMPS iteration):
+`size(FR) * (1 - 1/nprocs)`.
+
+Full FR exists only briefly within each `vumps_step` (between allgather and
+prescatter). After prescatter, `FR_full` is unreferenced and eligible for GC.
+
+For D=16, d=2, chi=768, Float64, nprocs=4: ~0.84 GiB / GPU (per site).
+For D=16, d=2, chi=768, Float64, nprocs=8: ~0.98 GiB / GPU (per site).
+
+### AD correctness
+
+Forward: `FR_dist → allgather → FR_full → rightenv → FR_full' → prescatter → FR_dist'`
+
+Backward (chain rule):
+- prescatter backward: zero-pad + allreduce → full gradient
+- rightenv backward: full → full
+- allgather backward: extract local slice (no communication)

--- a/src/autodiff/rules.jl
+++ b/src/autodiff/rules.jl
@@ -129,6 +129,45 @@ function ChainRulesCore.rrule(::Type{<:C4vVUMPSEnv}, AL, C, FL)
     return env, back
 end
 
+function ChainRulesCore.rrule(::typeof(prescatter_for_parallel), tensor, split_dim::Int, forloop_iter::Int)
+    comm = MPI.COMM_WORLD
+    rank = MPI.Comm_rank(comm)
+    nprocs = MPI.Comm_size(comm)
+    D_split = size(tensor, split_dim)
+    ranges = split_ranges(D_split, nprocs * forloop_iter)
+    first_idx = forloop_iter * rank + 1
+    last_idx  = forloop_iter * rank + forloop_iter
+    lo = first(ranges[first_idx])
+    hi = last(ranges[last_idx])
+    idx = ntuple(d -> d == split_dim ? (lo:hi) : (:), ndims(tensor))
+    result = tensor[idx...]
+    function back(d_result)
+        d_tensor = zero(tensor)
+        d_tensor[idx...] .= unthunk(d_result)
+        allreduce_p2p!(d_tensor, +, comm)
+        return NoTangent(), d_tensor, NoTangent(), NoTangent()
+    end
+    return result, back
+end
+
+function ChainRulesCore.rrule(::typeof(allgather_for_parallel), tensor_local, split_dim::Int, forloop_iter::Int, D_full::Int)
+    result = allgather_for_parallel(tensor_local, split_dim, forloop_iter, D_full)
+    function back(d_result)
+        comm = MPI.COMM_WORLD
+        rank = MPI.Comm_rank(comm)
+        nprocs = MPI.Comm_size(comm)
+        ranges = split_ranges(D_full, nprocs * forloop_iter)
+        first_idx = forloop_iter * rank + 1
+        last_idx  = forloop_iter * rank + forloop_iter
+        lo = first(ranges[first_idx])
+        hi = last(ranges[last_idx])
+        idx = ntuple(d -> d == split_dim ? (lo:hi) : (:), ndims(d_result))
+        d_local = unthunk(d_result)[idx...]
+        return NoTangent(), d_local, NoTangent(), NoTangent(), NoTangent()
+    end
+    return result, back
+end
+
 function ChainRulesCore.rrule(::Type{StructArray}, data, pattern)
     S = StructArray(data, pattern)
     function back(dS)
@@ -238,7 +277,7 @@ function ChainRulesCore.rrule(::typeof(forloop), f, args...; forloop_iter, N_in,
     end
 end
 
-function ChainRulesCore.rrule(::typeof(parallel), f, args...; forloop_iter, N_in, N_out, size_out, inner_etype=nothing)
+function ChainRulesCore.rrule(::typeof(parallel), f, args...; forloop_iter, N_in, N_out, size_out, inner_etype=nothing, input_prescattered=false)
     comm = MPI.COMM_WORLD
     rank = MPI.Comm_rank(comm)
     nprocs = MPI.Comm_size(comm)
@@ -253,16 +292,17 @@ function ChainRulesCore.rrule(::typeof(parallel), f, args...; forloop_iter, N_in
 
     Ain = args_c[N_in[1]]
     split_dim = N_in[2]
-    D_split = size(Ain, split_dim)
+    D_split = input_prescattered ? size_out[N_out] : size(Ain, split_dim)
     result_c = similar(args_c[1], size_out)
     D_split_ranges = split_ranges(D_split, nprocs * forloop_iter)
+    local_ranges = input_prescattered ? split_ranges(size(Ain, split_dim), forloop_iter) : nothing
 
     in_idx  = ntuple(_ -> (:), ndims(Ain))
     out_idx = ntuple(_ -> (:), ndims(result_c))
 
     for i in 1:forloop_iter
         ind = forloop_iter * rank + i
-        in_idx_r  = Base.setindex(in_idx,  D_split_ranges[ind], split_dim)
+        in_idx_r  = Base.setindex(in_idx, input_prescattered ? local_ranges[i] : D_split_ranges[ind], split_dim)
         out_idx_r = Base.setindex(out_idx, D_split_ranges[ind], N_out)
         split_args = ntuple(length(args_c)) do j
             j == N_in[1] ? @view(args_c[j][in_idx_r...]) : args_c[j]
@@ -283,7 +323,7 @@ function ChainRulesCore.rrule(::typeof(parallel), f, args...; forloop_iter, N_in
         dargs_c = ntuple(i -> args_c[i] isa Tuple ? zero.(args_c[i]) : zero(args_c[i]), length(args_c))
         @views for i in 1:forloop_iter
             ind = forloop_iter * rank + i
-            in_idx_r  = Base.setindex(in_idx,  D_split_ranges[ind], split_dim)
+            in_idx_r  = Base.setindex(in_idx, input_prescattered ? local_ranges[i] : D_split_ranges[ind], split_dim)
             out_idx_r = Base.setindex(out_idx, D_split_ranges[ind], N_out)
             split_args = ntuple(length(args_c)) do j
                 j == N_in[1] ? view(args_c[j], in_idx_r...) : args_c[j]
@@ -308,9 +348,12 @@ function ChainRulesCore.rrule(::typeof(parallel), f, args...; forloop_iter, N_in
         synchronize(args_c[1])
 
         # MPI collectives on dargs_c (still in inner_etype — 2× bandwidth).
-        has_split_gather = N_in[2] == ndims(args_c[N_in[1]])
+        # When input_prescattered, the split arg's gradient is already local-
+        # sized — no allgatherv needed.  The outer prescatter op (array
+        # indexing) handles placing the local gradient into the full tensor.
+        has_split_gather = !input_prescattered && N_in[2] == ndims(args_c[N_in[1]])
 
-        # 1) Allgatherv for split arg (if contiguous)
+        # 1) Allgatherv for split arg (if contiguous and not prescattered)
         if has_split_gather
             j = N_in[1]
             element_size = prod(size(dargs_c[j])) ÷ D_split
@@ -320,7 +363,7 @@ function ChainRulesCore.rrule(::typeof(parallel), f, args...; forloop_iter, N_in
 
         # 2) Allreduce non-split args via p2p with pre-allocated buffers
         for j in 1:length(args_c)
-            if j == N_in[1] && has_split_gather
+            if j == N_in[1] && (has_split_gather || input_prescattered)
                 continue
             end
             if dargs_c[j] isa Tuple

--- a/src/boundary_algorithm/vumps/general.jl
+++ b/src/boundary_algorithm/vumps/general.jl
@@ -21,6 +21,18 @@ permute_fronttail(t::leg4) = permutedims(t, (4,2,3,1))
 permute_fronttail(t::InnerProductVec) = RealVec(permute_fronttail(t.vec))
 permute_fronttail(t::AbstractZero) = t
 
+# ── FR distribution helpers (StructArray level) ─────────────────────
+
+function _prescatter_FR(FR::StructArray, forloop_iter::Int)
+    split_dim = ndims(FR.data[1])
+    StructArray([prescatter_for_parallel(d, split_dim, forloop_iter) for d in FR.data], FR.pattern)
+end
+
+function _allgather_FR(FR::StructArray, forloop_iter::Int, chi::Int)
+    split_dim = ndims(FR.data[1])
+    StructArray([allgather_for_parallel(d, split_dim, forloop_iter, chi) for d in FR.data], FR.pattern)
+end
+
 # ── Offload-friendly simple_eig wrappers ────────────────────────────
 # These accept the big neighbourhood tensors as explicit args so that
 # `checkpoint(Offload(), ...)` can move them to host memory during the backward
@@ -58,10 +70,11 @@ end
 function _simple_eig_ACmap(AC1j, FL_j, FR_j, M_j; power_iter, ifparallel, forloop_iter,
                             inner_checkpoint::CheckpointMethod=Plain(),
                             inner_etype=nothing, final_polish_steps=0,
-                            segment_checkpoint::CheckpointMethod=Plain())
-    f(x) = checkpoint(inner_checkpoint, ACmap, 1, x, FL_j, FR_j, M_j; ifparallel, forloop_iter, inner_etype)
+                            segment_checkpoint::CheckpointMethod=Plain(),
+                            fr_distributed=false)
+    f(x) = checkpoint(inner_checkpoint, ACmap, 1, x, FL_j, FR_j, M_j; ifparallel, forloop_iter, inner_etype, fr_distributed)
     if final_polish_steps > 0
-        f_final(x) = checkpoint(inner_checkpoint, ACmap, 1, x, FL_j, FR_j, M_j; ifparallel, forloop_iter, inner_etype=nothing)
+        f_final(x) = checkpoint(inner_checkpoint, ACmap, 1, x, FL_j, FR_j, M_j; ifparallel, forloop_iter, inner_etype=nothing, fr_distributed)
         return simple_eig(f, AC1j; power_iter, segment_checkpoint, f_final, final_polish_steps)
     else
         return simple_eig(f, AC1j; power_iter, segment_checkpoint)
@@ -526,11 +539,11 @@ end
 
 # ── AC and C environment updates ────────────────────────────────────
 
-function ACmap(I::Int, ACij, FLj, FRj, Mj; ifparallel, forloop_iter, inner_etype=nothing)
+function ACmap(I::Int, ACij, FLj, FRj, Mj; ifparallel, forloop_iter, inner_etype=nothing, fr_distributed=false)
     Ni = length(FLj)
     for i in I:(I + Ni - 1)
         ir = mod1(i, Ni)
-        ACij = ACmap_parallel(ACij, FLj[ir], FRj[ir], Mj[ir]; ifparallel, forloop_iter, inner_etype)
+        ACij = ACmap_parallel(ACij, FLj[ir], FRj[ir], Mj[ir]; ifparallel, forloop_iter, inner_etype, fr_distributed)
     end
     return ACij
 end
@@ -541,7 +554,7 @@ end
 Compute the up environment tensor for MPS `FL`, `FR` and MPO `M`, by finding the up fixed point
 of `FL - M - FR` contracted along the physical dimension.
 """
-function ACenv(AC, FL, M, FR; alg, kwargs...)
+function ACenv(AC, FL, M, FR; alg, fr_distributed=false, kwargs...)
     @unpack inner_etype, power_iter, forloop_iter, ifparallel,
             segment_checkpoint, inner_checkpoint, eig_checkpoint, ifsimple_eig, verbosity = alg
     # Env-level boundary cast — see leftenv for rationale.
@@ -565,7 +578,7 @@ function ACenv(AC, FL, M, FR; alg, kwargs...)
     for j in 1:Nj
         p = AC.pattern[1, j]
         if p ∉ processed_indices
-            f(AC1j) = checkpoint(inner_checkpoint, ACmap, 1, AC1j, FL[:, j], FR[:, j], M[:, j]; ifparallel, forloop_iter, inner_etype=inner_etype_pass)
+            f(AC1j) = checkpoint(inner_checkpoint, ACmap, 1, AC1j, FL[:, j], FR[:, j], M[:, j]; ifparallel, forloop_iter, inner_etype=inner_etype_pass, fr_distributed)
             if ifsimple_eig
                 λACs, ACs = checkpoint(eig_checkpoint, _simple_eig_ACmap,
                                         AC[1, j], FL[:, j], FR[:, j], M[:, j];
@@ -573,7 +586,8 @@ function ACenv(AC, FL, M, FR; alg, kwargs...)
                                         inner_checkpoint,
                                         inner_etype=inner_etype_pass,
                                         segment_checkpoint,
-                                        final_polish_steps = polish_fine ? simple_eig_polish_steps : 0)
+                                        final_polish_steps = polish_fine ? simple_eig_polish_steps : 0,
+                                        fr_distributed)
             else
                 λACs, ACs, info = eigsolve(f, AC[1, j], 1, :LM; alg_rrule=GMRES(verbosity=-1), maxiter=100, ishermitian=false, kwargs...)
                 verbosity >= 1 && info.converged == 0 && @warn "ACenv Not converged"
@@ -588,7 +602,7 @@ function ACenv(AC, FL, M, FR; alg, kwargs...)
         for i in 2:Ni
             p = AC.pattern[i, j]
             if p ∉ processed_indices
-                ACij = ACmap_parallel(AC′[i-1, j], FL[i-1, j], FR[i-1, j], M[i-1, j]; ifparallel, forloop_iter, inner_etype=inner_etype_pass)
+                ACij = ACmap_parallel(AC′[i-1, j], FL[i-1, j], FR[i-1, j], M[i-1, j]; ifparallel, forloop_iter, inner_etype=inner_etype_pass, fr_distributed)
                 AC′[i, j] = ACij / norm(ACij)
                 λAC[i, j] = λAC[1, j]
                 push!(processed_indices, p)
@@ -766,6 +780,9 @@ function init_VUMPSRuntime(M::StructArray,  χ::Int, alg::VUMPS{General})
     end
     _, FL = leftenv(AL, conj(AL), M; alg)
     _, FR = rightenv(AR, conj(AR), M; alg)
+    if alg.ifparallel
+        FR = _prescatter_FR(FR, alg.forloop_iter)
+    end
     return VUMPSRuntime(AL, AR, C, FL, FR)
 end
 
@@ -837,33 +854,41 @@ Uses the power-method variant: update environments first, then re-solve AC/C.
 """
 function vumps_step_power(rt::VUMPSRuntime, M::StructArray, alg::VUMPS{General})
     @unpack AL, C, AR, FL, FR = rt
+    @unpack ifparallel, forloop_iter = alg
     AC = ALCtoAC(AL, C)
-    _, ACp = ACenv(AC, FL, M, FR; alg)
-    _, Cp = Cenv(C, FL, FR; alg)
+    chi = size(FL.data[1], 1)
+    FR_full = ifparallel ? _allgather_FR(FR, forloop_iter, chi) : FR
+    _, Cp = Cenv(C, FL, FR_full; alg)
+    _, ACp = ACenv(AC, FL, M, FR; alg, fr_distributed=ifparallel)
     ALp, ARp, _, _ = ACCtoALAR(ACp, Cp)
     _, FL = leftenv(AL, conj(ALp), M, FL; alg)
-    _, FR = rightenv(AR, conj(ARp), M, FR; alg)
-    _, ACp = ACenv(ACp, FL, M, FR; alg)
-    _, Cp = Cenv(Cp, FL, FR; alg)
+    _, FR_full = rightenv(AR, conj(ARp), M, FR_full; alg)
+    _, Cp = Cenv(Cp, FL, FR_full; alg)
+    FR_dist = ifparallel ? _prescatter_FR(FR_full, forloop_iter) : FR_full
+    _, ACp = ACenv(ACp, FL, M, FR_dist; alg, fr_distributed=ifparallel)
     ALp, ARp, errL, errR = ACCtoALAR(ACp, Cp)
     err = errL + errR
     alg.verbosity >= 4 && err > 1e-8 && println("errL=$errL, errR=$errR")
     Cp = for_gc(Cp)
-    return VUMPSRuntime(ALp, ARp, Cp, FL, FR), err
+    return VUMPSRuntime(ALp, ARp, Cp, FL, FR_dist), err
 end
 
 function vumps_step(rt::VUMPSRuntime, M::StructArray, alg::VUMPS{General})
     @unpack AL, C, AR, FL, FR = rt
-    AC = ALCtoAC(AL,C)
+    @unpack ifparallel, forloop_iter = alg
+    AC = ALCtoAC(AL, C)
+    chi = size(FL.data[1], 1)
+    FR_full = ifparallel ? _allgather_FR(FR, forloop_iter, chi) : FR
     _, FL =  leftenv(AL, conj(AL), M, FL; alg)
-    _, FR = rightenv(AR, conj(AR), M, FR; alg)
-    _, AC = ACenv(AC, FL, M, FR; alg)
-    _,  C =  Cenv( C, FL, FR; alg)
+    _, FR_full = rightenv(AR, conj(AR), M, FR_full; alg)
+    _,  C =  Cenv( C, FL, FR_full; alg)
+    FR_dist = ifparallel ? _prescatter_FR(FR_full, forloop_iter) : FR_full
+    _, AC = ACenv(AC, FL, M, FR_dist; alg, fr_distributed=ifparallel)
     AL, AR, errL, errR = ACCtoALAR(AC, C)
     err = errL + errR
     alg.verbosity >= 4 && err > 1e-8 && println("errL=$errL, errR=$errR")
     C = for_gc(C)
-    return VUMPSRuntime(AL, AR, C, FL, FR), err
+    return VUMPSRuntime(AL, AR, C, FL, FR_dist), err
 end
 
 # ── VUMPS iteration loop ────────────────────────────────────────────
@@ -1030,6 +1055,11 @@ Construct a `VUMPSEnv` observation environment from a single VUMPS runtime.
 """
 function ObsEnv(rt::VUMPSRuntime, M::StructArray, alg::VUMPS{General}, Fo=[rt.FL, rt.FR])
     @unpack AL, AR, C, FL, FR = rt
+    if alg.ifparallel
+        chi = size(FL.data[1], 1)
+        FR = _allgather_FR(FR, alg.forloop_iter, chi)
+        Fo = [Fo[1], FR]
+    end
     AC = ALCtoAC(AL, C)
     _, FLo =  leftenv(AL, AL, M, Fo[1]; ifobs = true, alg)
     _, FRo = rightenv(AR, AR, M, Fo[2]; ifobs = true, alg)
@@ -1048,6 +1078,11 @@ function ObsEnv(rt::Tuple{VUMPSRuntime, VUMPSRuntime}, M::StructArray, alg::VUMP
     rtup, rtdown = rt
 
     ALu, ARu, Cu, FLu, FRu = rtup.AL, rtup.AR, rtup.C, rtup.FL, rtup.FR
+    if alg.ifparallel
+        chi = size(FLu.data[1], 1)
+        FRu = _allgather_FR(FRu, alg.forloop_iter, chi)
+        Fo = [Fo[1], FRu]
+    end
     ACu = ALCtoAC(ALu, Cu)
 
     ALd, ARd, Cd = rtdown.AL, rtdown.AR, rtdown.C

--- a/src/contraction/forloop_parallel_MPI.jl
+++ b/src/contraction/forloop_parallel_MPI.jl
@@ -21,6 +21,66 @@ function split_ranges(N::Integer, n::Integer)
     return split_ranges(counts)
 end
 
+"""
+    prescatter_for_parallel(tensor, split_dim, forloop_iter)
+
+Extract the local slice(s) of `tensor` that this MPI rank needs for
+`parallel(...; input_prescattered=true)`.  Returns a copy containing
+`forloop_iter` contiguous slices along `split_dim`, concatenated.
+
+AD-safe: index computation is inside `ignore_derivatives`; only the
+final `tensor[idx...]` participates in the Zygote tape.
+"""
+function prescatter_for_parallel(tensor, split_dim::Int, forloop_iter::Int)
+    idx = ChainRulesCore.ignore_derivatives() do
+        comm = MPI.COMM_WORLD
+        rank = MPI.Comm_rank(comm)
+        nprocs = MPI.Comm_size(comm)
+        D_split = size(tensor, split_dim)
+        ranges = split_ranges(D_split, nprocs * forloop_iter)
+        first_idx = forloop_iter * rank + 1
+        last_idx  = forloop_iter * rank + forloop_iter
+        lo = first(ranges[first_idx])
+        hi = last(ranges[last_idx])
+        ntuple(d -> d == split_dim ? (lo:hi) : (:), ndims(tensor))
+    end
+    return tensor[idx...]
+end
+
+"""
+    allgather_for_parallel(tensor_local, split_dim, forloop_iter, D_full)
+
+Inverse of `prescatter_for_parallel`: reconstruct the full tensor by
+allgathering each rank's local slice along `split_dim`.  `D_full` is
+the full extent of the split dimension (e.g. χ).
+
+Has a custom rrule in `autodiff/rules.jl`.
+"""
+function allgather_for_parallel(tensor_local, split_dim::Int, forloop_iter::Int, D_full::Int)
+    comm = MPI.COMM_WORLD
+    rank = MPI.Comm_rank(comm)
+    nprocs = MPI.Comm_size(comm)
+
+    ranges = split_ranges(D_full, nprocs * forloop_iter)
+
+    first_idx = forloop_iter * rank + 1
+    last_idx  = forloop_iter * rank + forloop_iter
+    lo = first(ranges[first_idx])
+    hi = last(ranges[last_idx])
+
+    full_shape = ntuple(d -> d == split_dim ? D_full : size(tensor_local, d), ndims(tensor_local))
+    result = similar(tensor_local, full_shape)
+    idx = ntuple(d -> d == split_dim ? (lo:hi) : (:), ndims(tensor_local))
+    result[idx...] = tensor_local
+    synchronize(tensor_local)
+
+    element_size = prod(full_shape) ÷ D_full
+    counts = Cint[sum(length(ranges[(i-1)*forloop_iter+j]) for j in 1:forloop_iter) * element_size for i in 1:nprocs]
+    allgatherv_p2p!(result, counts, comm)
+
+    return result
+end
+
 # ─── Pre-allocated communication buffers ──────────────────────────────────
 
 const _comm_sendbuf = Ref{Any}(nothing)
@@ -453,7 +513,7 @@ function forloop(f, args...; forloop_iter, N_in, N_out, size_out, inner_etype=no
     return do_cast ? T_orig.(result) : result
 end
 
-function parallel(f, args...; forloop_iter, N_in, N_out, size_out, inner_etype=nothing)
+function parallel(f, args...; forloop_iter, N_in, N_out, size_out, inner_etype=nothing, input_prescattered=false)
     comm = MPI.COMM_WORLD
     rank = MPI.Comm_rank(comm)
     nprocs = MPI.Comm_size(comm)
@@ -464,13 +524,22 @@ function parallel(f, args...; forloop_iter, N_in, N_out, size_out, inner_etype=n
         args = map(a -> _boundary_cast(inner_etype, a), args)
     end
 
-    D_split = size(args[N_in[1]])[N_in[2]]
+    D_split = input_prescattered ? size_out[N_out] : size(args[N_in[1]])[N_in[2]]
     result = similar(args[1], size_out)
     D_split_ranges = split_ranges(D_split, nprocs*forloop_iter)
 
+    if input_prescattered
+        local_arg = args[N_in[1]]
+        local_ranges = split_ranges(size(local_arg, N_in[2]), forloop_iter)
+    end
+
     for i in 1:forloop_iter
         ind = forloop_iter * rank + i
-        cols_in = (j == N_in[2] ? D_split_ranges[ind] : (:) for j in 1:ndims(args[N_in[1]]))
+        if input_prescattered
+            cols_in = (j == N_in[2] ? local_ranges[i] : (:) for j in 1:ndims(local_arg))
+        else
+            cols_in = (j == N_in[2] ? D_split_ranges[ind] : (:) for j in 1:ndims(args[N_in[1]]))
+        end
         cols_out = (j == N_out ? D_split_ranges[ind] : (:) for j in 1: ndims(result))
         split_args = Tuple(j == N_in[1] ? @view(args[j][cols_in...]) : args[j] for j in 1:length(args))
         result[cols_out...] = f(split_args...)
@@ -587,10 +656,10 @@ function FRmap_parallel(FR, ARu, ARd, M; ifparallel, forloop_iter, inner_etype=n
     end
 end
 
-function ACmap_parallel(AC, FL, FR, M; ifparallel, forloop_iter, inner_etype=nothing)
-    N_in = (3, ndims(FR))
-    N_out = ndims(FR)
-    χ = size(FR, 1)
+function ACmap_parallel(AC, FL, FR, M; ifparallel, forloop_iter, inner_etype=nothing, fr_distributed=false)
+    N_in = (3, fr_distributed ? ndims(FL) : ndims(FR))
+    N_out = ndims(FL)
+    χ = size(FL, 1)
     if M isa Tuple
         D1 = size(M[1], 2)
         D2 = size(M[2], 2)
@@ -603,7 +672,7 @@ function ACmap_parallel(AC, FL, FR, M; ifparallel, forloop_iter, inner_etype=not
         size_out = (χ,D,χ)
     end
     if ifparallel
-        return parallel(ACmap, AC, FL, FR, M; forloop_iter, N_in, N_out, size_out, inner_etype)
+        return parallel(ACmap, AC, FL, FR, M; forloop_iter, N_in, N_out, size_out, inner_etype, input_prescattered=fr_distributed)
     else
         return forloop(ACmap, AC, FL, FR, M; forloop_iter, N_in, N_out, size_out, inner_etype)
     end


### PR DESCRIPTION
## Summary

- Store only the local FR slice (split on last dim) in `VUMPSRuntime` — each GPU holds `FR_size / nprocs` instead of the full FR for the entire VUMPS iteration lifetime
- Each `vumps_step` allgathers FR once (for `rightenv`/`Cenv`), then prescatters before `ACenv`; `Cenv` is reordered before `ACenv` so the full FR can be GC'd during the expensive eigensolver
- Add `allgather_for_parallel()` (inverse of `prescatter_for_parallel`) with custom rrule (backward: local slice extraction, no communication)

## Memory savings

Per GPU, persistent: `size(FR) * (1 - 1/nprocs)`

| D | χ | nprocs | Savings/GPU (Float64) |
|---|---|--------|----------------------|
| 16 | 768 | 4 | ~0.84 GiB/site |
| 16 | 768 | 8 | ~0.98 GiB/site |

## Communication cost

One extra `allgatherv` per `vumps_step` (single collective — negligible vs eigensolver work).

## Changed files

- `src/contraction/forloop_parallel_MPI.jl` — `allgather_for_parallel()`, existing `parallel()`/`ACmap_parallel` infrastructure
- `src/autodiff/rules.jl` — rrule for `allgather_for_parallel`
- `src/boundary_algorithm/vumps/general.jl` — `vumps_step`/`vumps_step_power` reorder + allgather/prescatter, `init_VUMPSRuntime` prescatters, `ACenv` accepts `fr_distributed` kwarg, `ObsEnv` allgathers
- `docs/2026-05-08-distributed-FR-in-ACenv-design.md` — design spec

## Test plan

- [ ] Verify syntax (all 3 files pass `Meta.parseall`)
- [ ] Single-GPU correctness: serial path (`ifparallel=false`) unchanged
- [ ] Multi-GPU correctness: energy/observables match baseline
- [ ] AD correctness: gradient matches finite-difference check
- [ ] Memory profiling: confirm per-GPU FR footprint reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)