### PR TITLE
fix(SU/Kagome): correct gate construction for Kagome :merge simple update

### DIFF
--- a/src/ipeps_optimize/su_parameterization.jl
+++ b/src/ipeps_optimize/su_parameterization.jl
@@ -30,24 +30,35 @@ function SU_parameterization(A, params; D_new)
         throw(ArgumentError("SU_parameterization not yet implemented for $(typeof(params.model.lattice)) (gates would act on the empty site, producing wrong results)"))
     end
     if params.model.lattice isa Kagome{:merge}
+        # d above is the merged physical dim (d_single^3). The Kagome helpers
+        # work with the per-sublattice dim, so derive it from the model.
+        d_single = Int(2 * params.model.S + 1)
         terms = _heisenberg_bond_terms(params.model, Array; ifrotate=false)
         # Inter-cell H = bond(3→1)+bond(3→2), V = bond(3→1)+bond(2→1)
         function _build_kagome_twosite(sublattice_left, sublattice_right)
-            h = zeros(Float64, d^3, d^3, d^3, d^3)
+            h = zeros(Float64, d, d, d, d)
             for (c, OL, OR) in terms
-                OL_d3 = _kagome_site_op(OL, sublattice_left, d)
-                OR_d3 = _kagome_site_op(OR, sublattice_right, d)
-                @tensor o[a,b,c,d] := OL_d3[a,b] * OR_d3[c,d]
+                OL_d3 = _kagome_site_op(OL, sublattice_left, d_single)
+                OR_d3 = _kagome_site_op(OR, sublattice_right, d_single)
+                @tensor o[a,b,c,e] := OL_d3[a,b] * OR_d3[c,e]
                 h += c * real(o)
             end
             return h
         end
         h_H = _build_kagome_twosite(3, 1) + _build_kagome_twosite(3, 2)
         h_V = _build_kagome_twosite(3, 1) + _build_kagome_twosite(2, 1)
-        h_onsite = _kagome_onsite_op(terms, 1, 2, d, Array) + _kagome_onsite_op(terms, 2, 3, d, Array)
-        @tensor h_twosite[1,2,3,4] := h_onsite[1,2] * h_onsite[3,4]
-        h_H += h_twosite
-        h_V += h_twosite
+
+        # Intra-cell (1-2, 2-3) bonds sit on a single merged site. Distribute
+        # them symmetrically into the two-site gates as h_onsite⊗I + I⊗h_onsite.
+        # Each cell participates in 4 gates per sweep (left/right of H,
+        # upper/lower of V), so divide by 4 to recover unit Trotter weight.
+        h_onsite = _kagome_onsite_op(terms, 1, 2, d_single, Array) +
+                   _kagome_onsite_op(terms, 2, 3, d_single, Array)
+        Id = Matrix{Float64}(I, d, d)
+        @tensor h_twosite[a,b,c,e] := h_onsite[a,b] * Id[c,e] +
+                                      Id[a,b] * h_onsite[c,e]
+        h_H += h_twosite / 4
+        h_V += h_twosite / 4
     else
         terms = _heisenberg_bond_terms(params.model, Array)
         h = zeros(Float64, d, d, d, d)


### PR DESCRIPTION
## Summary

The Simple-Update gate builder for `Kagome{:merge}` in
[`src/ipeps_optimize/su_parameterization.jl`](https://github.com/XingyuZhang2018/TeneT.jl/blob/iPEPS-unified/src/ipeps_optimize/su_parameterization.jl)
had three issues that together prevent the code from running and would produce a wrong Hamiltonian if it did. Inter-cell coupling coefficients were already correct and are not touched.

## Bugs fixed

### 1. Wrong dimension passed to per-sublattice helpers (would OOM)

`d = size(A[1], 5)` is the merged dim (`d_single^3 = 8` for spin-1/2), but `_kagome_site_op` and `_kagome_onsite_op` expect the per-sublattice dim. Also, the gate tensor was being allocated as `(d^3, d^3, d^3, d^3)` — `(512, 512, 512, 512)` ≈ 540 GB for S=1/2 — causing an OOM before any real work could happen. A local reproduction with Julia 1.11 hits `OutOfMemoryError` on the `zeros(...)` call.

Fix: derive `d_single = Int(2*model.S + 1)` and pass that to the helpers, while keeping `d` (merged) for the gate shape `(d,d,d,d)`.

### 2. Onsite term used outer product instead of tensor sum

```julia
@tensor h_twosite[1,2,3,4] := h_onsite[1,2] * h_onsite[3,4]
```

This is `kron(h_onsite, h_onsite)` — a 4-body interaction between the two cells — not the intended single-site contribution `h_onsite⊗I + I⊗h_onsite`. Numerical check (S=1/2): the code matrix has Frobenius norm 3.0 vs 6.93 for the correct sum, rank 36 vs 60, and `code_matrix == kron(h_onsite, h_onsite)` exactly.

Fix:

```julia
@tensor h_twosite[a,b,c,e] := h_onsite[a,b]*Id[c,e] + Id[a,b]*h_onsite[c,e]
```

### 3. Onsite term double-counted

`h_twosite` was added unchanged to both `h_H` and `h_V`. In one SU sweep each cell appears in 4 gates (left/right of H, upper/lower of V), so the onsite Hamiltonian was evolved with weight 4 instead of 1.

Fix: divide by 4 before adding to each gate.

## Test plan

- [x] Local Julia 1.11 smoke test of just the gate-building path: gate tensors come out at the correct merged-dim shape `(8,8,8,8)`; `h_H`, `h_V`, `h_onsite` all Hermitian.
- [x] Reproduced that the original code OOMs on the first `zeros(...)` call for S=1/2 Kagome merge (consistent with `init_ipeps_SU` being commented out in the example).
- [ ] CI / repo test suite (no SU-merge test exists yet — would be worth adding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)