### PR TITLE
feat: :brickwall_v lattice + J1J2p energy (Stage 1)

### DIFF
--- a/examples/FWavePRVB/FWavePRVB_Honeycomb_VUMPS_General.jl
+++ b/examples/FWavePRVB/FWavePRVB_Honeycomb_VUMPS_General.jl
@@ -18,7 +18,7 @@ D, χ, χshift, maxiter_restart = 2, 16, 1, 100
 #            2 4 6 1 3 5]
 pattern = [1 3 5 7  9 11;
            2 4 6 8 10 12]
-model = FWavePRVB(lattice=Honeycomb(:brickwall), 
+model = FWavePRVB(lattice=Honeycomb(:brickwall_h), 
                   S=0.5, J1=0.5, K=1)
 No = 0
 folder = joinpath(pkgdir(TeneT), "data/$model/$pattern/VUMPS_General/$etype/seed$seed/")

--- a/examples/Heisenberg/Heisenberg_Honeycomb_VUMPS_General.jl
+++ b/examples/Heisenberg/Heisenberg_Honeycomb_VUMPS_General.jl
@@ -15,7 +15,7 @@ pattern = [1 2;
 # pattern = [1;;]
 # pattern = [1 3;
 #            2 4]
-model = Heisenberg(lattice=Honeycomb(:brickwall),
+model = Heisenberg(lattice=Honeycomb(:brickwall_h),
                    S=0.5, Jx=1.0, Jy=1.0, Jz=1.0,
                    ifrotate=false,
                    couplingtype=:uniform, bondratio=1.0)

--- a/examples/J1J2/J1J2_Honeycomb_VUMPS_General.jl
+++ b/examples/J1J2/J1J2_Honeycomb_VUMPS_General.jl
@@ -19,7 +19,7 @@ pattern = [1 3 5 2 4 6;
            2 4 6 1 3 5]
 # pattern = [1 3 5 7  9 11;
 #            2 4 6 8 10 12]
-model = J1J2(lattice=Honeycomb(:brickwall), 
+model = J1J2(lattice=Honeycomb(:brickwall_h), 
               S=0.5, J1=1.0, J2=0.3,
               ifrotate=false, 
               couplingtype=:plaquette, bondratio=0.1)

--- a/examples/J1J2/J1J2_Honeycomb_VUMPS_Plaquette.jl
+++ b/examples/J1J2/J1J2_Honeycomb_VUMPS_Plaquette.jl
@@ -19,7 +19,7 @@ pattern = [1 3 5 2 4 6;
            2 4 6 1 3 5]
 # pattern = [1 3 5 7  9 11;
 #            2 4 6 8 10 12]
-lattice = Honeycomb(:brickwall)
+lattice = Honeycomb(:brickwall_h)
 model = J1J2(lattice=lattice, 
              S=0.5, J1=1.0, J2=0.3,
              ifrotate=true, 

--- a/examples/J1J2J3/J1J2J3_Honeycomb_VUMPS_General.jl
+++ b/examples/J1J2J3/J1J2J3_Honeycomb_VUMPS_General.jl
@@ -19,7 +19,7 @@ pattern = [1 2;
 #            2 4 6 1 3 5]
 # pattern = [1 3 5 7  9 11;
 #            2 4 6 8 10 12]
-model = J1J2J3(lattice=Honeycomb(:brickwall), 
+model = J1J2J3(lattice=Honeycomb(:brickwall_h), 
               S=0.5, J1=1.0, J2=0.45, J3=0.2,
               ifrotate=false, 
               couplingtype=:plaquette, bondratio=1)

--- a/examples/J1J2J3/J1J2J3_Honeycomb_VUMPS_Plaquette.jl
+++ b/examples/J1J2J3/J1J2J3_Honeycomb_VUMPS_Plaquette.jl
@@ -19,7 +19,7 @@ pattern = [1 3 5 2 4 6;
            2 4 6 1 3 5]
 # pattern = [1 3 5 7  9 11;
 #            2 4 6 8 10 12]
-lattice = Honeycomb(:brickwall)
+lattice = Honeycomb(:brickwall_h)
 model = J1J2J3(lattice=lattice, 
                S=0.5, J1=1.0, J2=0.35, J3=0.1,
                ifrotate=true, 

--- a/examples/J1J2p/J1J2p_Honeycomb_VUMPS_General.jl
+++ b/examples/J1J2p/J1J2p_Honeycomb_VUMPS_General.jl
@@ -19,7 +19,7 @@ pattern = [1 3 5 2 4 6;
            2 4 6 1 3 5]
 # pattern = [1 3 5 7  9 11;
 #            2 4 6 8 10 12]
-model = J1J2p(lattice=Honeycomb(:brickwall), 
+model = J1J2p(lattice=Honeycomb(:brickwall_h), 
               S=0.5, J1=1.0, J2p=0.5,
               ifrotate=false, 
               couplingtype=:plaquette, bondratio=0.1)

--- a/examples/J1J2p/J1J2p_Honeycomb_brickwall_v_VUMPS_General.jl
+++ b/examples/J1J2p/J1J2p_Honeycomb_brickwall_v_VUMPS_General.jl
@@ -1,0 +1,88 @@
+using TeneT
+using Random
+using CUDA
+using OptimKit
+using LinearAlgebra
+using Zygote
+
+seed = 88
+Random.seed!(seed)
+atype = Array
+etype = Float64
+D, χ, χshift, maxiter_restart = 3, 8, 0, 100
+
+# 6×2 pattern (column-major friendly): each unique site (1..6) appears twice,
+# in a brickwall arrangement rotated 90° from the :brickwall_h pattern.
+pattern = [1 4;
+           2 5;
+           3 6;
+           4 1;
+           5 2;
+           6 3]
+
+# J1J2p model on the vertical-orientation honeycomb brickwall.
+# couplingtype=:plaquette is intentionally NOT used here — it's deferred until
+# the (i,j)→bondratio mapping for the :brickwall_v pattern is derived.
+# Use :uniform for now (Stage 1 benchmark).
+model = J1J2p(lattice=Honeycomb(:brickwall_v),
+              S=0.5, J1=1.0, J2p=0.3,
+              ifrotate=false,
+              couplingtype=:uniform, bondratio=1.0)
+No = 0
+folder = joinpath(pkgdir(TeneT), "data/$model/$pattern/VUMPS_General/$etype/seed$seed/")
+
+boundary_alg = VUMPS{General}(ifupdown=true,
+                              ifdownfromup=false,
+                              ifsimple_eig=true,
+                              ifparallelupdown=false,
+                              ifparallel=false,
+                              forloop_iter=1,
+                              maxiter=30,
+                              miniter=0,
+                              maxiter_ad=4,
+                              miniter_ad=4,
+                              power_iter=1,
+                              power_iter_ad=5,
+                              power_iter_obs=40,
+                              show_every=10,
+                              tol=1e-10,
+                              verbosity=3,
+)
+params = GradientOptimize(model=model,
+                          pattern=pattern,
+                          boundary_alg=boundary_alg,
+                          optimizer=LBFGS(200; maxiter=10, verbosity=4, gradtol=1e-7, linesearch=HagerZhangLineSearch(maxfg=5)),
+                          forloop_iter=1,
+                          maxiter_restart=maxiter_restart,
+                          verbosity=4,
+                          folder=folder,
+                          ifSU=false,
+                          SUτ=0,
+                          ifprecondition=true,
+                          iter_precond=0,
+                          reuse_env=true,
+                          ifsave_env=true,
+                          ifload_env=true,
+                          ifsave_lbfgs=true,
+                          ifload_lbfgs=false,
+)
+A = init_ipeps(; atype, etype, No, D, χ, params)
+
+# Restriction: map the 6 unique sites to 2 independent tensors by parity.
+# For :brickwall_v pattern [1 4; 2 5; 3 6; 4 1; 5 2; 6 3]:
+#   Even-parity sites: 1, 3, 5 (positions (1,1),(3,1),(5,1) and (4,2),(6,2),(2,2))
+#   Odd-parity sites:  2, 4, 6 (positions (2,1),(4,1),(6,1) and (5,2),(1,2),(3,2))
+function restriction_ipeps(A)
+    B = Zygote.Buffer(A)
+    for i in 1:length(A)
+        if i in [1, 3, 5]
+            B[:,:,:,:,:,i] = A[:,:,:,:,:,1]
+        elseif i in [2, 4, 6]
+            B[:,:,:,:,:,i] = A[:,:,:,:,:,2]
+        end
+    end
+    B = copy(B)
+    return B / norm(B)
+end
+
+optimise_ipeps(A, 8, χshift, params; restriction_ipeps);

--- a/examples/Kitaev/Kitaev_Honeycomb_brickwall_VUMPS_General.jl
+++ b/examples/Kitaev/Kitaev_Honeycomb_brickwall_VUMPS_General.jl
@@ -16,7 +16,7 @@ D, χ, χshift, maxiter_restart = 2, 20, 1, 10
 #            2 4]
 pattern = [1 3 5 2 4 6;
            2 4 6 1 3 5]
-model = Kitaev(lattice=Honeycomb(:brickwall), 
+model = Kitaev(lattice=Honeycomb(:brickwall_h), 
                S=0.5, Jx=-1.0, Jy=-1.0, Jz=-1.0, 
                couplingtype=:plaquette, bondratio=1.0)
 No = 3

--- a/src/boundary_algorithm/vumps/plaquette.jl
+++ b/src/boundary_algorithm/vumps/plaquette.jl
@@ -57,7 +57,7 @@ function ACenv_plaq(AC, FL, M; alg::VUMPS{L}, kwargs...) where L <: Plaquette
         p = AC.pattern[1,j]
         if L <: Plaquette{Square}
             jr = mod1(j + 1, Nj)
-        elseif L <: Plaquette{Honeycomb{:brickwall}}
+        elseif L <: Plaquette{Honeycomb{:brickwall_h}}
             jr = mod1(Nj - j , Nj)
         else
             error("Unsupported lattice for Plaquette VUMPS: $(L). Only Square and Honeycomb are supported.")
@@ -117,7 +117,7 @@ function Cenv_plaq(C, FL; alg::VUMPS{L}, kwargs...) where L <: Plaquette
         jl = mod1(j + 1, Nj)
         if L <: Plaquette{Square}
             jr = mod1(j + 1, Nj)
-        elseif L <: Plaquette{Honeycomb{:brickwall}}
+        elseif L <: Plaquette{Honeycomb{:brickwall_h}}
             jr = mod1(Nj - j , Nj)
         else
             error("Unsupported lattice for Plaquette VUMPS: $(L). Only Square and Honeycomb are supported.")

--- a/src/contraction/observable.jl
+++ b/src/contraction/observable.jl
@@ -162,11 +162,11 @@ function oc_31(ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1u, A1d, A2u, A2d, A
     return dot(conj(u), ACd)
 end
 
-function contract_n3_V(ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1, A2, A3; forloop_iter, ifparallel)
+function contract_n_31(ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1, A2, A3; forloop_iter, ifparallel)
     return oc_31(ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1, conj(A1), A2, conj(A2), A3, conj(A3); forloop_iter, ifparallel)
 end
 
-function contract_o3_V(ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1, A2, A3, O1, O2; forloop_iter, ifparallel)
+function contract_o_31(ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1, A2, A3, O1, O2; forloop_iter, ifparallel)
     @tensor A1u[a,b,c,d,f] := A1[a,b,c,d,e] * O1[e,f]
     @tensor A3u[a,b,c,d,f] := A3[a,b,c,d,e] * O2[e,f]
     return oc_31(ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1u, conj(A1), A2, conj(A2), A3u, conj(A3); forloop_iter, ifparallel)

--- a/src/ipeps_optimize/build_A.jl
+++ b/src/ipeps_optimize/build_A.jl
@@ -94,14 +94,14 @@ function _lattice_map(A, ::Kagome{:onehole_real}, pattern)
 end
 
 """
-    _lattice_map(A, ::Honeycomb{:brickwall}, pattern)
+    _lattice_map(A, ::Honeycomb{:brickwall_h}, pattern)
 
 Brickwall mapping: permute legs on odd-parity sites so the brickwall
 honeycomb maps onto a square lattice.
 """
-function _lattice_map(A, ::Honeycomb{:brickwall}, pattern)
+function _lattice_map(A, ::Honeycomb{:brickwall_h}, pattern)
     Ni, Nj = size(pattern)
-    Ni % 2 == 0 && Nj % 2 == 0 || throw(ArgumentError("For Honeycomb{:brickwall}, pattern must have even dimensions."))
+    Ni % 2 == 0 && Nj % 2 == 0 || throw(ArgumentError("For Honeycomb{:brickwall_h}, pattern must have even dimensions."))
     n_unique = length(unique(pattern))
     return StructArray([
         begin

--- a/src/ipeps_optimize/build_A.jl
+++ b/src/ipeps_optimize/build_A.jl
@@ -113,6 +113,26 @@ function _lattice_map(A, ::Honeycomb{:brickwall_h}, pattern)
 end
 
 """
+    _lattice_map(A, ::Honeycomb{:brickwall_v}, pattern)
+
+Vertical brickwall mapping: permute legs on odd-parity sites with `(3,4,1,2,5)`
+so the brickwall honeycomb maps onto a square lattice, with dim-1 leg
+alternating between `l` (even-parity) and `r` (odd-parity).
+"""
+function _lattice_map(A, ::Honeycomb{:brickwall_v}, pattern)
+    Ni, Nj = size(pattern)
+    Ni % 2 == 0 && Nj % 2 == 0 || throw(ArgumentError("For Honeycomb{:brickwall_v}, pattern must have even dimensions."))
+    n_unique = length(unique(pattern))
+    return StructArray([
+        begin
+            pos = findfirst(==(i), pattern)
+            sum(Tuple(pos)) % 2 == 0 ? A[i] : permutedims(A[i], (3,4,1,2,5))
+        end
+        for i in 1:n_unique
+    ], pattern)
+end
+
+"""
     _lattice_map(A, ::Honeycomb{:merge}, pattern)
 
 Merge mapping: identity (sites are already independent tensors on

--- a/src/ipeps_optimize/init.jl
+++ b/src/ipeps_optimize/init.jl
@@ -69,7 +69,7 @@ function _init_random_ipeps(::Honeycomb{:merge}, etype, D, d, N, Ni, Nj)
     rand(etype, D, D, D, D, d^2, N) .+ 1
 end
 
-function _init_random_ipeps(::Honeycomb{:brickwall}, etype, D, d, N, Ni, Nj)
+function _init_random_ipeps(::Honeycomb{:brickwall_h}, etype, D, d, N, Ni, Nj)
     Ni % 2 == 0 && Nj % 2 == 0 || throw(ArgumentError("Ni and Nj should be even for brickwall"))
     rand(etype, D, 1, D, D, d, N) .+ 1
 end

--- a/src/ipeps_optimize/init.jl
+++ b/src/ipeps_optimize/init.jl
@@ -74,6 +74,11 @@ function _init_random_ipeps(::Honeycomb{:brickwall_h}, etype, D, d, N, Ni, Nj)
     rand(etype, D, 1, D, D, d, N) .+ 1
 end
 
+function _init_random_ipeps(::Honeycomb{:brickwall_v}, etype, D, d, N, Ni, Nj)
+    Ni % 2 == 0 && Nj % 2 == 0 || throw(ArgumentError("Ni and Nj should be even for brickwall_v"))
+    rand(etype, 1, D, D, D, d, N) .+ 1
+end
+
 # --------------------------------------------------------------------------- #
 #  init_ipeps_to_D  —  enlarge bond dimension via SU parameterization
 # --------------------------------------------------------------------------- #

--- a/src/ipeps_optimize/observable.jl
+++ b/src/ipeps_optimize/observable.jl
@@ -52,7 +52,7 @@ function observable(A, χ, params::iPEPSOptimize; restriction_ipeps=_restriction
                          save_format=params.plot_format, S=params.model.S)
     end
 
-    # if params.model.lattice == Honeycomb(:brickwall)
+    # if params.model.lattice == Honeycomb(:brickwall_h)
     #     Wp_value(params.model, A, env, params)
     #     fwave_order(params.model, A, env, params)
     # end

--- a/src/ipeps_optimize/restriction.jl
+++ b/src/ipeps_optimize/restriction.jl
@@ -303,6 +303,20 @@ Returns `G1 * A * G2 * G3 * G4` contracted on the four virtual legs.
 """
 local_gauge_contraction(A, G) = @tensor out[e,f,g,h,p] := A[a,b,c,d,p] * G[1][e,a] * G[2][b,f] * G[3][c,g] * G[4][h,d]
 
+# Lattice-typed brickwall queries (replaces the old D2!=D4 heuristic)
+_is_brickwall(::Honeycomb{:brickwall_h}) = true
+_is_brickwall(::Honeycomb{:brickwall_v}) = true
+_is_brickwall(::AbstractLattice) = false
+
+# Odd-parity permutation for brickwall — same (3,4,1,2,5) for both h and v
+_brickwall_odd_perm(::Honeycomb{:brickwall_h}) = (3,4,1,2,5)
+_brickwall_odd_perm(::Honeycomb{:brickwall_v}) = (3,4,1,2,5)
+
+# Which leg is dim-1 for parity-dependent gauge sizes:
+# :brickwall_h → leg 2 (d-leg); :brickwall_v → leg 1 (l-leg)
+_brickwall_dim1_leg(::Honeycomb{:brickwall_h}) = 2
+_brickwall_dim1_leg(::Honeycomb{:brickwall_v}) = 1
+
 """
     gauge_transfer(A, G, params)
 
@@ -310,29 +324,33 @@ Apply gauge transformation to all sites of a multi-site iPEPS tensor `A` (6-leg,
 `G = [Gh, Gv]` are vectors of matrices indexed by site number (one matrix per site).
 Uses `params.pattern` to determine the unit cell layout.
 
-For Honeycomb{:brickwall_h} (detected by D2 ≠ D4), odd-parity sites are permuted with
-(3,4,1,2,5) before applying the gauge and permuted back afterwards, matching the
-brickwall orientation convention used in `_lattice_map`.  In this case Gv has mixed
-sizes: I(D2) at even-parity sites and D4×D4 matrices at odd-parity sites.
+For Honeycomb brickwall lattices (`:brickwall_h` or `:brickwall_v`, detected via
+`params.model.lattice`), odd-parity sites are permuted with (3,4,1,2,5) before
+applying the gauge and permuted back afterwards, matching the brickwall orientation
+convention used in `_lattice_map`. For `:brickwall_h`, Gv has parity-dependent sizes
+(`I(1)` at even-parity, `D×D` at odd-parity) while Gh is uniformly `D×D`; for
+`:brickwall_v`, Gh has parity-dependent sizes (`D×D` at even-parity, `I(1)` at
+odd-parity) while Gv is uniformly `D×D`.
 """
 function gauge_transfer(A, G, params)
     Gh, Gv = G
     pattern = params.pattern
+    lattice = params.model.lattice
     Ni, Nj = size(pattern)
-    D2, D4 = size(A, 2), size(A, 4)
-    brickwall = D2 != D4   # true only for Honeycomb{:brickwall_h}
+    is_bw = _is_brickwall(lattice)
+    perm = is_bw ? _brickwall_odd_perm(lattice) : nothing
     A_buf = Zygote.Buffer(A)
     for q in 1:size(A, 6)
         i, j = Tuple(findfirst(==(q), pattern))
         ir = mod1(i - 1, Ni)
         jr = mod1(j - 1, Nj)
         gauges = [inv(Gh[pattern[i,jr]]), Gv[q], Gh[q], inv(Gv[pattern[ir,j]])]
-        if brickwall && (i + j) % 2 != 0
-            # Odd-parity brickwall site: permute (l,d,r,u,p)→(r,u,l,d,p) so the effective
-            # dim-D bond becomes leg 2, apply gauge, then permute back.
+        if is_bw && (i + j) % 2 != 0
+            # Odd-parity brickwall site: permute legs so the effective dim-D bonds align
+            # with the canonical leg order, apply gauge, then permute back.
             A_buf[:,:,:,:,:,q] = permutedims(
-                local_gauge_contraction(permutedims(A[:,:,:,:,:,q], (3,4,1,2,5)), gauges),
-                (3,4,1,2,5)
+                local_gauge_contraction(permutedims(A[:,:,:,:,:,q], perm), gauges),
+                perm
             )
         else
             A_buf[:,:,:,:,:,q] = local_gauge_contraction(A[:,:,:,:,:,q], gauges)
@@ -347,9 +365,14 @@ end
 Find gauge matrices `G = [Gh, Gv]` that minimize the Frobenius norm of the
 gauge-transformed iPEPS tensor. Uses LBFGS optimization from OptimKit.
 
-Gauge matrices are stored as `Vector{Matrix}` (one matrix per site), allowing
-mixed sizes for Honeycomb{:brickwall_h}: even-parity sites get `I(D2)` (trivial,
-dim-1 bond), odd-parity sites get `I(D4)` (full D×D bond).
+Gauge matrices are stored as `Vector{Matrix}` (one matrix per site). Dispatch
+on `params.model.lattice` selects the appropriate gauge layout:
+
+- `Honeycomb{:brickwall_h}` (dim-1 on the d-leg): `Gv` has mixed sizes
+  (`I(D2)` at even-parity sites, `I(D4)` at odd-parity sites); `Gh` is uniformly `I(D1)`.
+- `Honeycomb{:brickwall_v}` (dim-1 on the l-leg): `Gh` has mixed sizes
+  (`I(D3)` at even-parity sites, `I(D1)` at odd-parity sites); `Gv` is uniformly `I(D2)`.
+- Other lattices: both gauges are uniform identity matrices of the corresponding sizes.
 """
 function find_local_min_norm_G(A, params)
     atype = _arraytype(A)
@@ -357,27 +380,51 @@ function find_local_min_norm_G(A, params)
 
     D1, D2, D3, D4, _, N = size(A)
     eltypeA = eltype(A)
-    brickwall = D2 != D4   # true only for Honeycomb{:brickwall_h}
+    lattice = params.model.lattice
 
-    # Horizontal gauge: D1×D1 per site (D1 == D3 always).
-    Gh_init = [Matrix{eltypeA}(I, D1, D1) for _ in 1:N]
-
-    # Vertical gauge: parity-dependent for brickwall, uniform D2×D2 otherwise.
-    # For brickwall: even-parity sites have the trivial dim-D2=1 bond → I(D2);
-    #               odd-parity sites have the real dim-D4=D bond → I(D4).
+    # Gauge initialization is lattice-dependent. The per-site gauge size must match
+    # the corresponding leg dimension AFTER the odd-parity permutation applied in
+    # `gauge_transfer`. Concretely:
+    #
+    # - :brickwall_h (raw shape (D,1,D,D,d,N), dim-1 on the d-leg):
+    #     Gh[q] lives on the r-leg (uniformly size D). Even-parity site: d-leg=1
+    #     (no perm), so Gv[q]=I(D2)=I(1). Odd-parity site: after perm (3,4,1,2,5)
+    #     the new d-leg = old r-leg of size D, so Gv[q]=I(D4)=I(D).
+    # - :brickwall_v (raw shape (1,D,D,D,d,N), dim-1 on the l-leg):
+    #     Gv[q] lives on the d-leg (uniformly size D). Even-parity site: r-leg=D
+    #     (no perm), so Gh[q]=I(D3)=I(D). Odd-parity site: after perm (3,4,1,2,5)
+    #     the new r-leg = old l-leg of size 1, so Gh[q]=I(D1)=I(1).
+    # - non-brickwall: Gh uniform D1×D1, Gv uniform D2×D2.
+    #
     # Parity is determined by findfirst(==(q), pattern), consistent with _lattice_map
-    # and gauge_transfer — NOT by cartindex[q] (which is column-major order, not site order).
-    # Both Gv and inv(Gv) are always applied in pairs (one on each side of the bond),
-    # so the optimization is well-posed regardless of bond dimension.
-    Gv_init = [
-        if brickwall
-            pos = findfirst(==(q), params.pattern)
-            sum(Tuple(pos)) % 2 == 0 ? Matrix{eltypeA}(I, D2, D2) : Matrix{eltypeA}(I, D4, D4)
+    # and gauge_transfer. Both gauges and their inverses are always applied in pairs
+    # (one on each side of a bond), so the optimization is well-posed regardless of
+    # the per-site bond dimension.
+    if _is_brickwall(lattice)
+        dim1_leg = _brickwall_dim1_leg(lattice)
+        if dim1_leg == 2   # :brickwall_h — Gv has parity-dependent sizes, Gh uniform
+            Gh_init = [Matrix{eltypeA}(I, D1, D1) for _ in 1:N]
+            Gv_init = [
+                let pos = findfirst(==(q), params.pattern)
+                    sum(Tuple(pos)) % 2 == 0 ? Matrix{eltypeA}(I, D2, D2) : Matrix{eltypeA}(I, D4, D4)
+                end
+                for q in 1:N
+            ]
+        elseif dim1_leg == 1   # :brickwall_v — Gh has parity-dependent sizes, Gv uniform
+            Gh_init = [
+                let pos = findfirst(==(q), params.pattern)
+                    sum(Tuple(pos)) % 2 == 0 ? Matrix{eltypeA}(I, D3, D3) : Matrix{eltypeA}(I, D1, D1)
+                end
+                for q in 1:N
+            ]
+            Gv_init = [Matrix{eltypeA}(I, D2, D2) for _ in 1:N]
         else
-            Matrix{eltypeA}(I, D2, D2)
+            error("Unsupported brickwall dim-1 leg position: $dim1_leg")
         end
-        for q in 1:N
-    ]
+    else
+        Gh_init = [Matrix{eltypeA}(I, D1, D1) for _ in 1:N]
+        Gv_init = [Matrix{eltypeA}(I, D2, D2) for _ in 1:N]
+    end
 
     Ginit = [Gh_init, Gv_init]
     function f(G)

--- a/src/ipeps_optimize/restriction.jl
+++ b/src/ipeps_optimize/restriction.jl
@@ -310,7 +310,7 @@ Apply gauge transformation to all sites of a multi-site iPEPS tensor `A` (6-leg,
 `G = [Gh, Gv]` are vectors of matrices indexed by site number (one matrix per site).
 Uses `params.pattern` to determine the unit cell layout.
 
-For Honeycomb{:brickwall} (detected by D2 ≠ D4), odd-parity sites are permuted with
+For Honeycomb{:brickwall_h} (detected by D2 ≠ D4), odd-parity sites are permuted with
 (3,4,1,2,5) before applying the gauge and permuted back afterwards, matching the
 brickwall orientation convention used in `_lattice_map`.  In this case Gv has mixed
 sizes: I(D2) at even-parity sites and D4×D4 matrices at odd-parity sites.
@@ -320,7 +320,7 @@ function gauge_transfer(A, G, params)
     pattern = params.pattern
     Ni, Nj = size(pattern)
     D2, D4 = size(A, 2), size(A, 4)
-    brickwall = D2 != D4   # true only for Honeycomb{:brickwall}
+    brickwall = D2 != D4   # true only for Honeycomb{:brickwall_h}
     A_buf = Zygote.Buffer(A)
     for q in 1:size(A, 6)
         i, j = Tuple(findfirst(==(q), pattern))
@@ -348,7 +348,7 @@ Find gauge matrices `G = [Gh, Gv]` that minimize the Frobenius norm of the
 gauge-transformed iPEPS tensor. Uses LBFGS optimization from OptimKit.
 
 Gauge matrices are stored as `Vector{Matrix}` (one matrix per site), allowing
-mixed sizes for Honeycomb{:brickwall}: even-parity sites get `I(D2)` (trivial,
+mixed sizes for Honeycomb{:brickwall_h}: even-parity sites get `I(D2)` (trivial,
 dim-1 bond), odd-parity sites get `I(D4)` (full D×D bond).
 """
 function find_local_min_norm_G(A, params)
@@ -357,7 +357,7 @@ function find_local_min_norm_G(A, params)
 
     D1, D2, D3, D4, _, N = size(A)
     eltypeA = eltype(A)
-    brickwall = D2 != D4   # true only for Honeycomb{:brickwall}
+    brickwall = D2 != D4   # true only for Honeycomb{:brickwall_h}
 
     # Horizontal gauge: D1×D1 per site (D1 == D3 always).
     Gh_init = [Matrix{eltypeA}(I, D1, D1) for _ in 1:N]

--- a/src/models/FWavePRVB/energy.jl
+++ b/src/models/FWavePRVB/energy.jl
@@ -14,7 +14,7 @@ the f-wave ground state (E_f = -2K).
 Set J1=0 for the pure ring exchange model.
 """
 @kwdef mutable struct FWavePRVB{L<:AbstractLattice} <: HamiltonianModel
-    lattice::L = Honeycomb(:brickwall)
+    lattice::L = Honeycomb(:brickwall_h)
     S::Real = 1/2
     J1::Real = 0.0
     K::Real = 1.0     # ring exchange coupling
@@ -23,7 +23,7 @@ Set J1=0 for the pure ring exchange model.
 end
 
 """
-    energy_value(model::FWavePRVB, A, env, params::iPEPSOptimize{:brickwall})
+    energy_value(model::FWavePRVB, A, env, params::iPEPSOptimize{:brickwall_h})
 
 Energy = J1 Σ_NN ⟨S⃗ᵢ·S⃗ⱼ⟩  -  K Σ_hexagons ⟨K₆⟩
 
@@ -33,7 +33,7 @@ The K₆ = C₆ + C₆⁻¹ ring exchange term is decomposed as:
     ⟨K₆⟩ = 2 Re(⟨C₆⟩)
 Each term is evaluated via contract_o_23 with 6 one-site projectors.
 """
-function energy_value(model::FWavePRVB{Honeycomb{:brickwall}}, A, env, params::iPEPSOptimize)
+function energy_value(model::FWavePRVB{Honeycomb{:brickwall_h}}, A, env, params::iPEPSOptimize)
     @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
     atype = _arraytype(ACu[1])
     Ni, Nj = size(ACu)

--- a/src/models/Heisenberg/energy.jl
+++ b/src/models/Heisenberg/energy.jl
@@ -130,7 +130,7 @@ function energy_value(model::Heisenberg{Square}, A, env::CTMEnv, params::iPEPSOp
     return etol*2, e_dict
 end
 
-function energy_value(model::Heisenberg{Honeycomb{:brickwall}}, A, env::VUMPSEnv, params::iPEPSOptimize)
+function energy_value(model::Heisenberg{Honeycomb{:brickwall_h}}, A, env::VUMPSEnv, params::iPEPSOptimize)
     @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
     atype = _arraytype(ACu[1])
     Ni, Nj = size(ACu)

--- a/src/models/J1J2/energy.jl
+++ b/src/models/J1J2/energy.jl
@@ -13,7 +13,7 @@ J1-J2 Heisenberg model with nearest-neighbor coupling `J1` and next-nearest-neig
     ifrotate::Bool = true
     couplingtype::Symbol = :uniform # :uniform, :plaquette, :dimmer1, :dimmer2, :mixed
     bondratio::Real = 1.0 # only used when couplingtype is not :uniform
-                          # for Honeycomb{:brickwall}, bondratio<1 is plaquette, bondratio>1 is dimmer
+                          # for Honeycomb{:brickwall_h}, bondratio<1 is plaquette, bondratio>1 is dimmer
 end
 
 function energy_value(model::J1J2{Square}, A, env::VUMPSEnv, params::iPEPSOptimize)
@@ -201,7 +201,7 @@ function energy_value(model::J1J2{Square}, A, env::CTMEnv, params::iPEPSOptimize
     return etol*2, e_dict
 end
 
-function energy_value(model::J1J2{Honeycomb{:brickwall}}, A, env::VUMPSEnv, params::iPEPSOptimize)
+function energy_value(model::J1J2{Honeycomb{:brickwall_h}}, A, env::VUMPSEnv, params::iPEPSOptimize)
     @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
     @unpack J2 = model
     atype = _arraytype(ACu[1])
@@ -273,7 +273,7 @@ function energy_value(model::J1J2{Honeycomb{:brickwall}}, A, env::VUMPSEnv, para
     return etol/len, e_dict
 end
 
-function energy_value(model::J1J2{Honeycomb{:brickwall}}, A, env::PlaquetteVUMPSEnv, params::iPEPSOptimize)
+function energy_value(model::J1J2{Honeycomb{:brickwall_h}}, A, env::PlaquetteVUMPSEnv, params::iPEPSOptimize)
     model.ifrotate == true || throw(ArgumentError("model.ifrotate must be true for Plaquette VUMPS energy evaluation"))
 
     @unpack AL, C, FLu, FLo = env

--- a/src/models/J1J2/order_init.jl
+++ b/src/models/J1J2/order_init.jl
@@ -60,14 +60,14 @@ function enlarge_coupling(model::J1J2{Square}, ::Val{:mixed}, i, j)
     return J1h, J1v
 end
 
-function enlarge_coupling(model::J1J2{Honeycomb{:brickwall}}, ::Val{:uniform}, i, j)
+function enlarge_coupling(model::J1J2{Honeycomb{:brickwall_h}}, ::Val{:uniform}, i, j)
     J1 = model.J1
     J1h = J1v = J1
 
     return J1h, J1v
 end
 
-function enlarge_coupling(model::J1J2{Honeycomb{:brickwall}}, ::Val{:plaquette}, i, j)
+function enlarge_coupling(model::J1J2{Honeycomb{:brickwall_h}}, ::Val{:plaquette}, i, j)
     @unpack J1, bondratio = model
     J1h = J1v = J1
     if (i,j) in [(1,2),(2,5)]

--- a/src/models/J1J2J3/energy.jl
+++ b/src/models/J1J2J3/energy.jl
@@ -3,7 +3,7 @@ export J1J2J3
 """
     J1J2J3{L<:AbstractLattice}
 
-J1-J2-J3 Heisenberg model with nearest-neighbor coupling `J1` and next-nearest-neighbor coupling `J2` and next-next-nearest-neighbor coupling `J3`. The model is defined on a lattice `L`, which can be specified by the user (e.g., `Square()`, `Honeycomb(:brickwall)`, etc.). The spin magnitude is given by `S`. The parameter `ifrotate` determines whether to rotate the spin operators in the Hamiltonian, and `couplingtype` specifies the type of coupling pattern (e.g., uniform, plaquette, dimmer, etc.). The `bondratio` parameter is used to adjust the coupling strength for non-uniform patterns.
+J1-J2-J3 Heisenberg model with nearest-neighbor coupling `J1` and next-nearest-neighbor coupling `J2` and next-next-nearest-neighbor coupling `J3`. The model is defined on a lattice `L`, which can be specified by the user (e.g., `Square()`, `Honeycomb(:brickwall_h)`, etc.). The spin magnitude is given by `S`. The parameter `ifrotate` determines whether to rotate the spin operators in the Hamiltonian, and `couplingtype` specifies the type of coupling pattern (e.g., uniform, plaquette, dimmer, etc.). The `bondratio` parameter is used to adjust the coupling strength for non-uniform patterns.
 """
 @kwdef mutable struct J1J2J3{L<:AbstractLattice} <: HamiltonianModel
     lattice::L = Square()
@@ -14,10 +14,10 @@ J1-J2-J3 Heisenberg model with nearest-neighbor coupling `J1` and next-nearest-n
     ifrotate::Bool = true
     couplingtype::Symbol = :uniform # :uniform, :plaquette, :dimmer1, :dimmer2, :mixed
     bondratio::Real = 1.0 # only used when couplingtype is not :uniform
-                          # for Honeycomb{:brickwall}, bondratio<1 is plaquette, bondratio>1 is dimmer
+                          # for Honeycomb{:brickwall_h}, bondratio<1 is plaquette, bondratio>1 is dimmer
 end
 
-function energy_value(model::J1J2J3{Honeycomb{:brickwall}}, A, env::VUMPSEnv, params::iPEPSOptimize)
+function energy_value(model::J1J2J3{Honeycomb{:brickwall_h}}, A, env::VUMPSEnv, params::iPEPSOptimize)
     @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
     @unpack J2, J3 = model
     atype = _arraytype(ACu[1])
@@ -127,7 +127,7 @@ function energy_value(model::J1J2J3{Honeycomb{:brickwall}}, A, env::VUMPSEnv, pa
     return etol/len, e_dict
 end
 
-function energy_value(model::J1J2J3{Honeycomb{:brickwall}}, A, env::PlaquetteVUMPSEnv, params::iPEPSOptimize)
+function energy_value(model::J1J2J3{Honeycomb{:brickwall_h}}, A, env::PlaquetteVUMPSEnv, params::iPEPSOptimize)
     model.ifrotate == true || throw(ArgumentError("model.ifrotate must be true for Plaquette VUMPS energy evaluation"))
 
     @unpack AL, C, FLu, FLo = env

--- a/src/models/J1J2J3/order_init.jl
+++ b/src/models/J1J2J3/order_init.jl
@@ -1,11 +1,11 @@
-function enlarge_coupling(model::J1J2J3{Honeycomb{:brickwall}}, ::Val{:uniform}, i, j)
+function enlarge_coupling(model::J1J2J3{Honeycomb{:brickwall_h}}, ::Val{:uniform}, i, j)
     J1 = model.J1
     J1h = J1v = J1
 
     return J1h, J1v
 end
 
-function enlarge_coupling(model::J1J2J3{Honeycomb{:brickwall}}, ::Val{:plaquette}, i, j)
+function enlarge_coupling(model::J1J2J3{Honeycomb{:brickwall_h}}, ::Val{:plaquette}, i, j)
     @unpack J1, bondratio = model
     J1h = J1v = J1
     if (i,j) in [(1,2),(2,5)]

--- a/src/models/J1J2p/energy.jl
+++ b/src/models/J1J2p/energy.jl
@@ -6,7 +6,7 @@ export J1J2p
 J1-J2p Heisenberg model with nearest-neighbor coupling `J1` and next-nearest-neighbor coupling `J2p` on a given lattice, but only on the one triangle not two on the Honeycomb lattice.
 """
 @kwdef mutable struct J1J2p{L<:AbstractLattice} <: HamiltonianModel
-    lattice::L = Honeycomb{:brickwall}()
+    lattice::L = Honeycomb{:brickwall_h}()
     S::Real = 1/2
     J1::Real = 1.0
     J2p::Real = 0.5
@@ -15,7 +15,7 @@ J1-J2p Heisenberg model with nearest-neighbor coupling `J1` and next-nearest-nei
     bondratio::Real = 1.0 # only used when couplingtype is not :uniform
 end
 
-function energy_value(model::J1J2p{Honeycomb{:brickwall}}, A, env::VUMPSEnv, params::iPEPSOptimize)
+function energy_value(model::J1J2p{Honeycomb{:brickwall_h}}, A, env::VUMPSEnv, params::iPEPSOptimize)
     @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
     @unpack J2p = model
     atype = _arraytype(ACu[1])

--- a/src/models/J1J2p/energy.jl
+++ b/src/models/J1J2p/energy.jl
@@ -88,3 +88,120 @@ function energy_value(model::J1J2p{Honeycomb{:brickwall_h}}, A, env::VUMPSEnv, p
     params.verbosity >= 3 && println("energy per site = $(etol/len)")
     return etol/len, e_dict
 end
+
+"""
+    energy_value(model::J1J2p{Honeycomb{:brickwall_v}}, A, env::VUMPSEnv, params)
+
+Bond enumeration on the vertical brickwall (rotated 90° relative to `:brickwall_h`):
+
+| Bond | Coupling | Parity                | Primitive             |
+|------|----------|-----------------------|-----------------------|
+| J1V  | J1       | every site            | `contract_*_21`       |
+| J1H  | J1·br    | `(i+j)%2 != 0`        | `contract_*_12`       |
+| J2/  | J2p      | `(i+j)%2 != 0`        | `contract_*_22_2`     |
+| J2\\  | J2p      | `(i+j)%2 == 0`        | `contract_*_22_1`     |
+| J2V  | J2p      | `(i+j)%2 == 0`        | `contract_*_31` (3×1) |
+
+Row reflections (obs convention `ir = Ni + 1 - i_strip_bottom`):
+- 2-row strip (J1V, J2 diag): `irr = mod1(Ni - i, Ni)`     (bottom row `i+1`)
+- 3-row strip (J2V):          `ir_d = mod1(Ni - 1 - i, Ni)` (bottom row `i+2`)
+
+J2 diagonal and J2V bonds connect same-sublattice sites → `terms_norot`
+(mirrors `:brickwall_h` J2/ / J2\\ / J2H convention, which also pin `terms_norot`).
+"""
+function energy_value(model::J1J2p{Honeycomb{:brickwall_v}}, A, env::VUMPSEnv, params::iPEPSOptimize)
+    @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
+    @unpack J2p = model
+    atype = _arraytype(ACu[1])
+    Ni, Nj = size(ACu)
+    len = length(ACu.data)
+
+    terms = _heisenberg_bond_terms(model, atype)
+    terms_norot = _heisenberg_bond_terms(model, atype; ifrotate=false)
+
+    e_dict = Dict{String, Dict{String, Any}}(
+        "bond_J1H_energy"  => Dict{String, Any}(),
+        "bond_J1V_energy"  => Dict{String, Any}(),
+        "bond_J2V_energy"  => Dict{String, Any}(),
+        "bond_J2\\_energy" => Dict{String, Any}(),
+        "bond_J2/_energy"  => Dict{String, Any}()
+    )
+    etol = 0.0
+    for p in 1:len
+        i, j = Tuple(findfirst(==(p), ACu.pattern))
+
+        params.verbosity >= 4 && println("===========$i,$j===========")
+        J1h, J1v = enlarge_coupling(model, i, j)
+
+        # ── J1V (always): vertical pair (i, j) ↔ (i+1, j) ──────────────────
+        ir  = mod1(i + 1, Ni)
+        irr = mod1(Ni - i, Ni)
+        e = _contract_barebones(contract_o_21, (ACu[i,j],FLu[i,j],A[i,j],FRu[i,j],FLo[ir,j],A[ir,j],FRo[ir,j],ACd[irr,j]), terms, params)
+        n = _contract_one(contract_n_21, (ACu[i,j],FLu[i,j],A[i,j],FRu[i,j],FLo[ir,j],A[ir,j],FRo[ir,j],ACd[irr,j]), params)
+        params.verbosity >= 4 && println("bond_J1V = $(J1v * e/n)")
+        etol += J1v * e/n
+        e_dict["bond_J1V_energy"]["$(i),$(j)"] = J1v * e/n
+
+        if (i + j) % 2 != 0
+            # ── J1H: horizontal pair (i, j) ↔ (i, j+1) ─────────────────────
+            ir = Ni + 1 - i
+            jr = mod1(j + 1, Nj)
+            e = _contract_barebones(contract_o_12, (FLo[i,j],ACu[i,j],A[i,j],ACd[ir,j],FRo[i,jr],ARu[i,jr],A[i,jr],ARd[ir,jr]), terms, params)
+            n = _contract_one(contract_n_12, (FLo[i,j],ACu[i,j],A[i,j],ACd[ir,j],FRo[i,jr],ARu[i,jr],A[i,jr],ARd[ir,jr]), params)
+            params.verbosity >= 4 && println("bond_J1H = $(J1h * e/n)")
+            etol += J1h * e/n
+            e_dict["bond_J1H_energy"]["$(i),$(j)"] = J1h * e/n
+
+            # ── J2/: 2×2 plaquette diagonal (i, j+1) ↔ (i+1, j) ────────────
+            ir  = mod1(i + 1, Ni)
+            irr = mod1(Ni - i, Ni)
+            jr = mod1(j + 1, Nj)
+            e2 = _contract_barebones(contract_o_22_2, (FLu[i,j], FLo[ir,j], ACu[i,j], ACd[irr,j], FRu[i,jr], FRo[ir,jr], ARu[i,jr], ARd[irr,jr], A[i,j], A[i,jr], A[ir,j], A[ir,jr]), terms_norot, params)
+            n =  _contract_one(contract_n_22, (FLu[i,j], FLo[ir,j], ACu[i,j], ACd[irr,j], FRu[i,jr], FRo[ir,jr], ARu[i,jr], ARd[irr,jr], A[i,j], A[i,jr], A[ir,j], A[ir,jr]), params)
+            params.verbosity >= 4 && println("bond_J2/ = $(J2p * e2/n)")
+            etol += J2p * e2/n
+            e_dict["bond_J2/_energy"]["$(i),$(j)"] = J2p * e2/n
+        else
+            # ── J2\\: 2×2 plaquette diagonal (i, j) ↔ (i+1, j+1) ───────────
+            ir  = mod1(i + 1, Ni)
+            irr = mod1(Ni - i, Ni)
+            jr = mod1(j + 1, Nj)
+            e1 = _contract_barebones(contract_o_22_1, (FLu[i,j], FLo[ir,j], ACu[i,j], ACd[irr,j], FRu[i,jr], FRo[ir,jr], ARu[i,jr], ARd[irr,jr], A[i,j], A[i,jr], A[ir,j], A[ir,jr]), terms_norot, params)
+            n =  _contract_one(contract_n_22, (FLu[i,j], FLo[ir,j], ACu[i,j], ACd[irr,j], FRu[i,jr], FRo[ir,jr], ARu[i,jr], ARd[irr,jr], A[i,j], A[i,jr], A[ir,j], A[ir,jr]), params)
+            params.verbosity >= 4 && println("bond_J2\\ = $(J2p * e1/n)")
+            etol += J2p * e1/n
+            e_dict["bond_J2\\_energy"]["$(i),$(j)"] = J2p * e1/n
+
+            # ── J2V: vertical triple (i, j) ↔ (i+2, j) skipping (i+1, j) ──
+            # contract_*_31 signature (observable.jl:165-173):
+            #   (ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1, A2, A3)
+            # propagates ACu through 3 rows (FLu1/FRu1, FLu2/FRu2, FLo/FRo)
+            # closing with `dot(conj(u), ACd)`.
+            # ACu at row 1 (top, i), ACd at row 3-bottom obs reflection.
+            # ir_d = Ni + 1 - (i+2) = Ni - 1 - i (obs reflection of bottom row).
+            ir1 = mod1(i + 1, Ni)         # middle row of strip
+            ir2 = mod1(i + 2, Ni)         # bottom row of strip
+            ir_d = mod1(Ni - 1 - i, Ni)   # obs reflection of bottom row
+            e = _contract_barebones(contract_o_31,
+                (ACu[i,j], ACd[ir_d,j],
+                 FLu[i,j],   FRu[i,j],     # row 1 (top) up env
+                 FLu[ir1,j], FRu[ir1,j],   # row 2 (middle) up env (no operator)
+                 FLo[ir2,j], FRo[ir2,j],   # row 3 (bottom) obs env
+                 A[i,j], A[ir1,j], A[ir2,j]),
+                terms_norot, params)
+            n = _contract_one(contract_n_31,
+                (ACu[i,j], ACd[ir_d,j],
+                 FLu[i,j],   FRu[i,j],
+                 FLu[ir1,j], FRu[ir1,j],
+                 FLo[ir2,j], FRo[ir2,j],
+                 A[i,j], A[ir1,j], A[ir2,j]),
+                params)
+            params.verbosity >= 4 && println("bond_J2V = $(J2p * e/n)")
+            etol += J2p * e/n
+            e_dict["bond_J2V_energy"]["$(i),$(j)"] = J2p * e/n
+        end
+    end
+
+    params.verbosity >= 3 && println("energy per site = $(etol/len)")
+    return etol/len, e_dict
+end

--- a/src/models/J1J2p/order_init.jl
+++ b/src/models/J1J2p/order_init.jl
@@ -26,5 +26,10 @@ function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall_v}}, ::Val{:uniform}
 end
 
 function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall_v}}, ::Val{:plaquette}, i, j)
-    error("J1J2p{Honeycomb{:brickwall_v}} with couplingtype=:plaquette is not yet implemented. The (i,j) → bondratio mapping for the 6×2 pattern [1 4; 2 5; 3 6; 4 1; 5 2; 6 3] requires user-provided physical bond identification. Use :uniform for now.")
+    throw(ArgumentError(
+        "J1J2p{Honeycomb{:brickwall_v}} with couplingtype=:plaquette is not yet implemented. " *
+        "The (i,j) → bondratio mapping for the 6×2 pattern [1 4; 2 5; 3 6; 4 1; 5 2; 6 3] " *
+        "requires user-provided physical bond identification. " *
+        "Use couplingtype=:uniform for now."
+    ))
 end

--- a/src/models/J1J2p/order_init.jl
+++ b/src/models/J1J2p/order_init.jl
@@ -17,3 +17,14 @@ function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall_h}}, ::Val{:plaquett
 
     return J1h, J1v
 end
+
+function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall_v}}, ::Val{:uniform}, i, j)
+    J1 = model.J1
+    J1h = J1v = J1
+
+    return J1h, J1v
+end
+
+function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall_v}}, ::Val{:plaquette}, i, j)
+    error("J1J2p{Honeycomb{:brickwall_v}} with couplingtype=:plaquette is not yet implemented. The (i,j) → bondratio mapping for the 6×2 pattern [1 4; 2 5; 3 6; 4 1; 5 2; 6 3] requires user-provided physical bond identification. Use :uniform for now.")
+end

--- a/src/models/J1J2p/order_init.jl
+++ b/src/models/J1J2p/order_init.jl
@@ -1,11 +1,11 @@
-function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall}}, ::Val{:uniform}, i, j)
+function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall_h}}, ::Val{:uniform}, i, j)
     J1 = model.J1
     J1h = J1v = J1
 
     return J1h, J1v
 end
 
-function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall}}, ::Val{:plaquette}, i, j)
+function enlarge_coupling(model::J1J2p{Honeycomb{:brickwall_h}}, ::Val{:plaquette}, i, j)
     @unpack J1, bondratio = model
     J1h = J1v = J1
     if (i,j) in [(1,2),(2,5)]

--- a/src/models/Kitaev/energy.jl
+++ b/src/models/Kitaev/energy.jl
@@ -6,7 +6,7 @@ export Kitaev
 Kitaev model with couplings `Jx`, `Jy`, `Jz` on a given lattice.
 """
 @kwdef mutable struct Kitaev{L<:AbstractLattice} <: HamiltonianModel
-    lattice::L = Honeycomb{:brickwall}()
+    lattice::L = Honeycomb{:brickwall_h}()
     S::Real = 1/2
     Jx::Real = -1.0
     Jy::Real = -1.0
@@ -15,7 +15,7 @@ Kitaev model with couplings `Jx`, `Jy`, `Jz` on a given lattice.
     bondratio::Real = 1.0 # bondratio < 1.0 for plaquette >1.0 for dimer
 end
 
-function energy_value(model::Kitaev{Honeycomb{:brickwall}}, A, env::VUMPSEnv, params::iPEPSOptimize)
+function energy_value(model::Kitaev{Honeycomb{:brickwall_h}}, A, env::VUMPSEnv, params::iPEPSOptimize)
     @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
     atype = _arraytype(A[1])
     Ni, Nj = size(A)

--- a/src/models/Kitaev/order_init.jl
+++ b/src/models/Kitaev/order_init.jl
@@ -1,9 +1,9 @@
-function enlarge_coupling(model::Kitaev{Honeycomb{:brickwall}}, ::Val{:uniform}, i, j)
+function enlarge_coupling(model::Kitaev{Honeycomb{:brickwall_h}}, ::Val{:uniform}, i, j)
     @unpack Jx, Jy, Jz = model
     return Jx, Jy, Jz
 end
 
-function enlarge_coupling(model::Kitaev{Honeycomb{:brickwall}}, ::Val{:plaquette}, i, j)
+function enlarge_coupling(model::Kitaev{Honeycomb{:brickwall_h}}, ::Val{:plaquette}, i, j)
     @unpack Jx, Jy, Jz, bondratio = model
     if (i,j) in [(1,2),(2,5)]
         Jy *= bondratio

--- a/src/visualization/plot_obs.jl
+++ b/src/visualization/plot_obs.jl
@@ -714,7 +714,7 @@ end
 # Site coordinates
 # ============================================================================
 
-function _site_xy(::Honeycomb{:brickwall}, i, j)
+function _site_xy(::Honeycomb{:brickwall_h}, i, j)
     x = (j - 1) * sqrt(3) / 2
     y = -(i - 1) * 1.5 - ((i + j) % 2 == 1 ? 0.5 : 0.0)
     return (x, y)
@@ -798,7 +798,7 @@ function _bond_linewidth(eval, e_min, e_max)
     return 3.0 + t * 18.0
 end
 
-function _draw_lattice_bonds!(ax, ::Honeycomb{:brickwall}, all_coords, all_mdata,
+function _draw_lattice_bonds!(ax, ::Honeycomb{:brickwall_h}, all_coords, all_mdata,
                                e_dict, pattern, unique_sites, Ni, Nj, n_repeat,
                                e_min, e_max)
     pval_positions = Dict{Int, Vector{Tuple{Int,Int}}}()

--- a/test/test_contraction.jl
+++ b/test/test_contraction.jl
@@ -542,4 +542,34 @@
             end
         end
     end
+
+    # =========================================================================
+    # Vertical-3 strip contraction (Task 5)
+    # =========================================================================
+    @testset "contract_n_31 smoke test — atype=$atype" for atype in ATYPES
+        # Verify the renamed vertical-3 norm primitive is callable and returns
+        # a sensible (non-zero, finite) value. End-to-end physics correctness
+        # is exercised in Task 9's benchmark; this is a naming/wiring sanity check.
+        Random.seed!(7)
+        T = ComplexF64
+        d = 2  # physical leg
+
+        # 3 site tensors (5-leg, iPEPS convention: l, d, r, u, p)
+        A1 = atype(randn(T, D, D, D, D, d))
+        A2 = atype(randn(T, D, D, D, D, d))
+        A3 = atype(randn(T, D, D, D, D, d))
+
+        # leg5 path: ACu/ACd are rank-4 (χ, D, D, χ), envs are rank-4 (χ, D, D, χ)
+        ACu = atype(randn(T, χ, D, D, χ))
+        ACd = atype(randn(T, χ, D, D, χ))
+
+        FLu1 = atype(randn(T, χ, D, D, χ)); FRu1 = atype(randn(T, χ, D, D, χ))
+        FLu2 = atype(randn(T, χ, D, D, χ)); FRu2 = atype(randn(T, χ, D, D, χ))
+        FLo  = atype(randn(T, χ, D, D, χ)); FRo  = atype(randn(T, χ, D, D, χ))
+
+        n = TeneT.contract_n_31(ACu, ACd, FLu1, FRu1, FLu2, FRu2, FLo, FRo, A1, A2, A3;
+                                forloop_iter=1, ifparallel=false)
+        @test isfinite(n)
+        @test n != zero(T)
+    end
 end

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -331,4 +331,70 @@
         @test_throws ArgumentError TeneT.enlarge_coupling(m_plaq, 1, 1)
     end
 
+    # ================================================================
+    # energy_value(::J1J2p{Honeycomb{:brickwall_v}}, ...) smoke test
+    # Exercises: dispatch + bond enumeration (J1V/J1H/J2//J2\\/J2V keys).
+    # Indices and absolute values are validated by the Stage-1 :h↔:v
+    # benchmark in examples/; this test only catches structural breakage
+    # (MethodErrors, wrong arity, missing bond keys).
+    # ================================================================
+    @testset "energy_value J1J2p :brickwall_v smoke" begin
+        using OptimKit: LBFGS
+        using TeneT: ObsEnv, energy_value, build_A,
+                     leading_boundary, initialize_env, J1J2p
+
+        Random.seed!(7)
+        D, χ = 2, 4
+        pattern = [1 4; 2 5; 3 6; 4 1; 5 2; 6 3]
+        model = J1J2p(lattice=Honeycomb{:brickwall_v}(),
+                      S=0.5, J1=1.0, J2p=0.3,
+                      ifrotate=false,
+                      couplingtype=:uniform, bondratio=1.0)
+        folder = mktempdir()
+        boundary_alg = VUMPS{TeneT.General}(ifupdown=true, ifsimple_eig=true,
+                                            maxiter=3, miniter=0,
+                                            maxiter_ad=1, miniter_ad=1,
+                                            tol=1e-3, verbosity=0, show_every=1000)
+        params = GradientOptimize(model=model, pattern=pattern,
+                                  boundary_alg=boundary_alg,
+                                  optimizer=LBFGS(10; maxiter=1, gradtol=1e-3, verbosity=0),
+                                  maxiter_restart=1, verbosity=0, folder=folder,
+                                  ifSU=false, SUτ=0.0, ifprecondition=false,
+                                  reuse_env=true, ifsave_env=false, ifload_env=false,
+                                  ifsave_lbfgs=false, ifload_lbfgs=false)
+
+        # Raw shape for :brickwall_v is (1, D, D, D, d, N) — dim-1 on l-leg.
+        # `pattern` has 6 unique site labels, so N = 6.
+        d, N = 2, 6
+        A_raw = (rand(Float64, 1, D, D, D, d, N) .- 0.5)
+        A_raw /= norm(A_raw)
+        A = build_A(A_raw, params)
+
+        rt = initialize_env(A_raw, D, χ, params)
+        rt, _ = leading_boundary(rt, A, params.boundary_alg)
+        env = ObsEnv(rt, A, params.boundary_alg)
+
+        e, e_dict = energy_value(model, A, env, params)
+        @test isfinite(e)
+        # All 5 bond categories should be present in the dict
+        @test haskey(e_dict, "bond_J1V_energy")
+        @test haskey(e_dict, "bond_J1H_energy")
+        @test haskey(e_dict, "bond_J2/_energy")
+        @test haskey(e_dict, "bond_J2\\_energy")
+        @test haskey(e_dict, "bond_J2V_energy")
+        # J1V is always-on → every (i,j) contributes
+        @test length(e_dict["bond_J1V_energy"]) == length(unique(pattern))
+        # Parity-conditional bonds populate half the sites
+        @test !isempty(e_dict["bond_J1H_energy"])
+        @test !isempty(e_dict["bond_J2/_energy"])
+        @test !isempty(e_dict["bond_J2\\_energy"])
+        @test !isempty(e_dict["bond_J2V_energy"])
+        # Each per-bond entry must be finite
+        for key in keys(e_dict)
+            for (_, v) in e_dict[key]
+                @test isfinite(v)
+            end
+        end
+    end
+
 end

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -22,7 +22,7 @@
         D, d = 2, 2
         tensors = [randn(D, 1, D, D, d) for _ in 1:4]
         A = StructArray(tensors, pattern)
-        A_out = _lattice_map(A, Honeycomb{:brickwall}(), pattern)
+        A_out = _lattice_map(A, Honeycomb{:brickwall_h}(), pattern)
         # _lattice_map iterates over data indices 1:length(unique(pattern))
         # and uses CartesianIndices(pattern) with linear indexing to determine parity.
         # For pattern [1 2; 3 4] (column-major):
@@ -167,7 +167,7 @@
         @test size(A_hm) == (D, D, D, D, d^2, N)
 
         # Honeycomb brickwall: (D,1,D,D,d,N)
-        A_hb = _init_random_ipeps(Honeycomb{:brickwall}(), Float64, D, d, N, Ni, Nj)
+        A_hb = _init_random_ipeps(Honeycomb{:brickwall_h}(), Float64, D, d, N, Ni, Nj)
         @test size(A_hb) == (D, 1, D, D, d, N)
 
         # Kagome :onehole — (D,D,D,D,d,N), requires Ni,Nj even

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -318,4 +318,17 @@
         @test Ah2 ≈ Ah
     end
 
+    @testset "enlarge_coupling J1J2p :brickwall_v" begin
+        # Uniform: J1h = J1v = J1 for all (i,j)
+        m_unif = J1J2p(lattice=Honeycomb{:brickwall_v}(), J1=1.5, J2p=0.3, couplingtype=:uniform)
+        @test TeneT.enlarge_coupling(m_unif, 1, 1) == (1.5, 1.5)
+        @test TeneT.enlarge_coupling(m_unif, 3, 2) == (1.5, 1.5)
+        @test TeneT.enlarge_coupling(m_unif, 6, 2) == (1.5, 1.5)
+
+        # Plaquette mode is intentionally deferred — calling it should error clearly
+        m_plaq = J1J2p(lattice=Honeycomb{:brickwall_v}(), J1=1.0, J2p=0.3,
+                       couplingtype=:plaquette, bondratio=0.5)
+        @test_throws ErrorException TeneT.enlarge_coupling(m_plaq, 1, 1)
+    end
+
 end

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -253,4 +253,25 @@
         @test_throws ArgumentError TeneT._init_random_ipeps(Honeycomb{:brickwall_v}(), Float64, D, d, N, 2, 3)
     end
 
+    @testset "_lattice_map :brickwall_v" begin
+        D, d = 3, 2
+        Ni, Nj = 4, 2
+        N = Ni * Nj
+        pattern = reshape(1:N, Ni, Nj)
+        A_raw = rand(Float64, 1, D, D, D, d, N)  # initial shape for :brickwall_v
+        A = TeneT.StructArray([A_raw[:,:,:,:,:,i] for i in 1:N], pattern)
+        Ar = TeneT._lattice_map(A, Honeycomb{:brickwall_v}(), pattern)
+
+        # Even-parity site: unchanged → shape (1,D,D,D,d)
+        # Odd-parity site: permutedims (3,4,1,2,5) → (D,D,1,D,d)
+        for i in 1:N
+            pos = findfirst(==(i), pattern)
+            if sum(Tuple(pos)) % 2 == 0
+                @test size(Ar[i]) == (1, D, D, D, d)
+            else
+                @test size(Ar[i]) == (D, D, 1, D, d)
+            end
+        end
+    end
+
 end

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -274,4 +274,48 @@
         end
     end
 
+    @testset "gauge_transfer dispatches on lattice for :brickwall_v" begin
+        using LinearAlgebra: I
+        D, d = 2, 2
+        Ni, Nj = 2, 2
+        N = Ni * Nj
+        pattern = reshape(1:N, Ni, Nj)
+        # :brickwall_v shape (1, D, D, D, d, N) — dim-1 on l-leg
+        A = rand(Float64, 1, D, D, D, d, N)
+
+        # Identity gauges for :brickwall_v.  Gh[q] lives on the r-leg (post-permutation),
+        # whose size depends on parity:
+        #   even-parity site (no permutation): r-leg size = D3 = D  → Gh = I(D)
+        #   odd-parity site  (after (3,4,1,2,5) permutation): new r-leg = old l-leg = D1 = 1
+        #                                                    → Gh = I(1)
+        # Gv[q] lives on the d-leg, always size D2 = D in :brickwall_v.
+        Gh = [begin
+                  pos = findfirst(==(q), pattern)
+                  sum(Tuple(pos)) % 2 == 0 ? Matrix{Float64}(I, D, D) : Matrix{Float64}(I, 1, 1)
+              end for q in 1:N]
+        Gv = [Matrix{Float64}(I, D, D) for _ in 1:N]
+
+        mock_params = (pattern=pattern, model=(lattice=Honeycomb{:brickwall_v}(),))
+        A2 = TeneT.gauge_transfer(A, [Gh, Gv], mock_params)
+
+        # Identity gauges should leave A unchanged (and the routing through the lattice
+        # type ensures the gauges land on the right legs for both parities).
+        @test size(A2) == size(A)
+        @test A2 ≈ A
+
+        # Sanity: gauge_transfer with `:brickwall_h` (existing logic) still works as before.
+        # For :brickwall_h, Gh is uniform I(D) (r-leg always size D), while Gv is parity-mixed
+        # (d-leg size 1 at even-parity, D at odd-parity).
+        Ah = rand(Float64, D, 1, D, D, d, N)
+        Gh_h = [Matrix{Float64}(I, D, D) for _ in 1:N]
+        Gv_h = [begin
+                    pos = findfirst(==(q), pattern)
+                    sum(Tuple(pos)) % 2 == 0 ? Matrix{Float64}(I, 1, 1) : Matrix{Float64}(I, D, D)
+                end for q in 1:N]
+        mock_params_h = (pattern=pattern, model=(lattice=Honeycomb{:brickwall_h}(),))
+        Ah2 = TeneT.gauge_transfer(Ah, [Gh_h, Gv_h], mock_params_h)
+        @test size(Ah2) == size(Ah)
+        @test Ah2 ≈ Ah
+    end
+
 end

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -242,4 +242,15 @@
         @test result ≈ real(dot(dx1, dx2))
     end
 
+    @testset "_init_random_ipeps :brickwall_v" begin
+        D, d, N, Ni, Nj = 3, 2, 6, 6, 2
+        A = TeneT._init_random_ipeps(Honeycomb{:brickwall_v}(), Float64, D, d, N, Ni, Nj)
+        @test size(A) == (1, D, D, D, d, N)   # dim-1 on l leg
+        @test eltype(A) == Float64
+
+        # Constraint: Ni, Nj both even
+        @test_throws ArgumentError TeneT._init_random_ipeps(Honeycomb{:brickwall_v}(), Float64, D, d, N, 3, 2)
+        @test_throws ArgumentError TeneT._init_random_ipeps(Honeycomb{:brickwall_v}(), Float64, D, d, N, 2, 3)
+    end
+
 end

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -328,7 +328,7 @@
         # Plaquette mode is intentionally deferred — calling it should error clearly
         m_plaq = J1J2p(lattice=Honeycomb{:brickwall_v}(), J1=1.0, J2p=0.3,
                        couplingtype=:plaquette, bondratio=0.5)
-        @test_throws ErrorException TeneT.enlarge_coupling(m_plaq, 1, 1)
+        @test_throws ArgumentError TeneT.enlarge_coupling(m_plaq, 1, 1)
     end
 
 end

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -3,11 +3,11 @@
     # ---- Lattice type hierarchy ----
     @testset "Lattice types" begin
         @test Square() isa TeneT.AbstractLattice
-        @test Honeycomb() isa TeneT.AbstractLattice
+        @test Honeycomb{:brickwall_h}() isa TeneT.AbstractLattice
         @test Kagome() isa TeneT.AbstractLattice
 
-        # Honeycomb default mode is :brickwall
-        @test Honeycomb() isa Honeycomb{:brickwall}
+        # Honeycomb default mode is :brickwall_h
+        @test Honeycomb{:brickwall_h}() isa Honeycomb{:brickwall_h}
         @test Honeycomb{:merge}() isa Honeycomb{:merge}
         @test Honeycomb{:merge}() isa TeneT.AbstractLattice
     end
@@ -15,7 +15,7 @@
     # ---- Lattice show methods ----
     @testset "Lattice show" begin
         @test sprint(show, Square()) == "Square"
-        @test sprint(show, Honeycomb()) == "Honeycomb_brickwall"
+        @test sprint(show, Honeycomb{:brickwall_h}()) == "Honeycomb_brickwall_h"
         @test sprint(show, Honeycomb{:merge}()) == "Honeycomb_merge"
         @test sprint(show, Kagome()) == "Kagome"
     end


### PR DESCRIPTION
## Summary

Stage 1 of a two-stage refactor:
1. Renames `Honeycomb{:brickwall}` → `Honeycomb{:brickwall_h}` (one-shot breaking).
2. Adds `Honeycomb{:brickwall_v}` (90°-rotated vertical brickwall: dim-1 leg on `l`, alternating horizontal bonds).
3. Implements `energy_value(::J1J2p{Honeycomb{:brickwall_v}}, A, env::VUMPSEnv, params)` via existing General VUMPS.

Stage 2 (Oneside{Model} VUMPS algorithm) follows in a separate PR.

## Benchmark (Stage 1 acceptance gate)

D=2, χ=8, J1=1.0, seed=88, both lattices, both J2p values:

| Config | E (`:brickwall_h`) | E (`:brickwall_v`) | rel diff |
|--------|---|---|---|
| J2p=0.3, uniform | -0.4607 | -0.4585 | 4.76e-03 |
| J2p=0.5, uniform | -0.4161 | -0.4058 | 2.47e-02 |

**Initial-state (random) energies agree to 1e-7** — bond enumeration is structurally correct. Final-state ~1-2% drift comes from limited LBFGS budget (10 iter × 2 restarts), not structural issues. Full convergence would close the gap.

## Breaking change

Existing on-disk `data/.../Honeycomb_brickwall/...` folders are orphaned (because `Base.show(::Honeycomb{:brickwall_h})` produces `"Honeycomb_brickwall_h"`). Rename manually to `Honeycomb_brickwall_h` or rerun.

## Deferred to follow-up PR(s)

- **`couplingtype=:plaquette` for `:brickwall_v`** — errors clearly with a message directing users to `:uniform`. Re-enabling requires the user to derive the `(i,j) → bondratio` mapping for the 6×2 pattern.
- **`find_local_hermite_G` for `:brickwall_v`** — latent issue: that function uses uniform `I(D,D)` gauges which now mismatch the parity-aware sizes that `gauge_transfer` expects. Only matters if a workload calls `local_hermite` on a `:brickwall_v` model (J1J2p example uses `local_min_norm`, not affected). Recommend a guard in a follow-up.

## Plan corrections discovered during implementation

- **Task 4**: gauge size parity for `:brickwall_v` should be even→I(D3), odd→I(D1) (plan had even→I(D1), odd→I(D3) — verified via identity-gauge test that produces `A2 ≈ A` only with the correct assignment).
- **Task 5**: vertical-3 primitive already existed as `contract_*3_V`; renamed to `contract_*_31` for consistency with horizontal `contract_*_13`.
- **Task 7**: actual signature of `contract_*_31` is 11 args (plan stub showed 12).

## Test plan

- [x] `Pkg.test()` — pre-existing failures unchanged; all new testsets pass
  - Task 2: `_init_random_ipeps :brickwall_v` — 4/4
  - Task 3: `_lattice_map :brickwall_v` — 8/8
  - Task 4: `gauge_transfer dispatches on lattice for :brickwall_v` — 4/4
  - Task 5: `contract_n_31 smoke test` — 2/2 (CPU + CUDA)
  - Task 6: `enlarge_coupling J1J2p :brickwall_v` — 4/4
  - Task 7: `energy_value J1J2p :brickwall_v smoke` — 29/29
- [x] Smoke run on the new example file (D=3, χ=8, J2p=0.3, 2 LBFGS iters): energy decreases from f=0.486 → f=-0.293
- [x] Benchmark: 2 uniform configs at D=2 (see table above)

## Stage 2 prerequisites

After this PR merges, Stage 2 (`docs/plans/2026-05-12-vertical-brickwall-stage2-plan.md`) can begin. Stage 2 adds:
- `Oneside{Model} <: ContractionMode`
- `OnesideVUMPSEnv` (6 fields, no separate ACd/ARd)
- `leftenv_oneside` / `rightenv_oneside` (model-aware row pairing)
- `energy_value(::J1J2p{:brickwall_v}, A, env::OnesideVUMPSEnv, params)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)