### PR TITLE
feat(ipeps): split_honeycomb_merge — SVD reverse of Honeycomb A/B merge

### DIFF
--- a/src/ipeps_optimize/build_A.jl
+++ b/src/ipeps_optimize/build_A.jl
@@ -145,12 +145,12 @@ _lattice_map(A, ::Honeycomb{:merge}, pattern) = A
 # --------------------------------------------------------------------------- #
 
 """
-    split_honeycomb_merge(M; convention=:LU_RD, χmax=0, cutoff=0.0)
+    split_honeycomb_merge(M; convention=:LU_RD, Dtrunc=0, cutoff=0.0)
 
 Reverse the Honeycomb sublattice merge.  Given a merged single-site tensor
 `M` of shape `(D, D, D, D, d²)`, return two sublattice tensors `A` and `B`,
 each carrying three virtual legs and one physical leg, joined by a freshly
-created internal virtual bond of dimension `χ ≤ D²·d`.
+created internal virtual bond of dimension `Dtrunc ≤ D²·d`.
 
 The merged physical index is interpreted in Julia's column-major reshape
 order — `σ_A` is the inner (fast) index and `σ_B` the outer:
@@ -172,19 +172,22 @@ Two leg-splitting conventions are supported (`convention` keyword):
 
       M[L, D, R, U, σ_AB] = Σ_x  A[L, D, σ_A, x] · B[x, R, U, σ_B]
 
-Truncation: keep all `D²d` singular values by default.  `χmax > 0` caps the
-internal bond; `cutoff > 0` discards `S[i] ≤ cutoff · S[1]`.  Singular
+Truncation: keep all `D²d` singular values by default.  `Dtrunc > 0` caps
+the internal bond; `cutoff > 0` discards `S[i] ≤ cutoff · S[1]`.  Singular
 values are distributed evenly between the two tensors (`A·√S` and `√S·B'`).
+
+(The new bond is intentionally not named `χ` to avoid clashing with the
+VUMPS boundary environment bond dimension.)
 
 Returns a NamedTuple `(A, B, S)`:
 
-* `A`: shape `(D, D, d, χ)` — index order `(extA1, extA2, σ_A, x_internal)`
-* `B`: shape `(χ, D, D, d)` — index order `(x_internal, extB1, extB2, σ_B)`
-* `S`: kept singular values (length `χ`)
+* `A`: shape `(D, D, d, Dtrunc)` — order `(extA1, extA2, σ_A, x_internal)`
+* `B`: shape `(Dtrunc, D, D, d)` — order `(x_internal, extB1, extB2, σ_B)`
+* `S`: kept singular values (length `Dtrunc`)
 """
 function split_honeycomb_merge(M::AbstractArray{T,5};
                                convention::Symbol = :LU_RD,
-                               χmax::Int = 0,
+                               Dtrunc::Int = 0,
                                cutoff::Real = 0.0) where T
     DL, DD, DR, DU, dphys = size(M)
     DL == DD == DR == DU || throw(ArgumentError(
@@ -208,24 +211,24 @@ function split_honeycomb_merge(M::AbstractArray{T,5};
         throw(ArgumentError("convention must be :LU_RD or :LD_RU, got $(convention)"))
     end
 
-    χfull = D * D * d
-    M_mat = reshape(M_perm, χfull, χfull)
+    Dfull = D * D * d
+    M_mat = reshape(M_perm, Dfull, Dfull)
     U, S, V = svd(M_mat)
 
-    χ = χmax > 0 ? min(χmax, length(S)) : length(S)
+    Dkeep = Dtrunc > 0 ? min(Dtrunc, length(S)) : length(S)
     if cutoff > 0
         smax = first(S)
-        χcut = findlast(s -> s > cutoff * smax, S)
-        χ = min(χ, χcut === nothing ? 1 : χcut)
+        Dcut = findlast(s -> s > cutoff * smax, S)
+        Dkeep = min(Dkeep, Dcut === nothing ? 1 : Dcut)
     end
 
-    Sχ  = S[1:χ]
-    sqs = sqrt.(Sχ)
-    A_mat = U[:, 1:χ] * Diagonal(sqs)              # (D²d, χ)
-    B_mat = Diagonal(sqs) * V[:, 1:χ]'             # (χ, D²d)
+    Skeep = S[1:Dkeep]
+    sqs   = sqrt.(Skeep)
+    A_mat = U[:, 1:Dkeep] * Diagonal(sqs)             # (D²d, Dkeep)
+    B_mat = Diagonal(sqs) * V[:, 1:Dkeep]'            # (Dkeep, D²d)
 
-    A = reshape(A_mat, D, D, d, χ)
-    B = reshape(B_mat, χ, D, D, d)
+    A = reshape(A_mat, D, D, d, Dkeep)
+    B = reshape(B_mat, Dkeep, D, D, d)
 
-    return (A = A, B = B, S = Sχ)
+    return (A = A, B = B, S = Skeep)
 end

--- a/src/ipeps_optimize/build_A.jl
+++ b/src/ipeps_optimize/build_A.jl
@@ -139,3 +139,93 @@ Merge mapping: identity (sites are already independent tensors on
 the effective square lattice; the merge is encoded in the Hamiltonian).
 """
 _lattice_map(A, ::Honeycomb{:merge}, pattern) = A
+
+# --------------------------------------------------------------------------- #
+#  split_honeycomb_merge  —  reverse the A/B sublattice merge via SVD
+# --------------------------------------------------------------------------- #
+
+"""
+    split_honeycomb_merge(M; convention=:LU_RD, χmax=0, cutoff=0.0)
+
+Reverse the Honeycomb sublattice merge.  Given a merged single-site tensor
+`M` of shape `(D, D, D, D, d²)`, return two sublattice tensors `A` and `B`,
+each carrying three virtual legs and one physical leg, joined by a freshly
+created internal virtual bond of dimension `χ ≤ D²·d`.
+
+The merged physical index is interpreted in Julia's column-major reshape
+order — `σ_A` is the inner (fast) index and `σ_B` the outer:
+
+    M[L, D, R, U, σ_AB]  with  σ_AB = σ_A + (σ_B - 1)·d
+
+Two leg-splitting conventions are supported (`convention` keyword):
+
+* `:LU_RD` (default; "anti-diagonal" merge) — A keeps the L and U bonds of
+  the effective cell, B keeps the R and D bonds:
+
+      M[L, D, R, U, σ_AB] = Σ_x  A[L, U, σ_A, x] · B[x, R, D, σ_B]
+
+  This matches the natural merge of u and v sublattices via the `a` bond
+  (u.R ↔ v.L) in the brickwall/featureless-honeycomb convention where
+  `u` has external legs (L, U) and `v` has external legs (R, D).
+
+* `:LD_RU` ("diagonal" merge) — A keeps L and D, B keeps R and U:
+
+      M[L, D, R, U, σ_AB] = Σ_x  A[L, D, σ_A, x] · B[x, R, U, σ_B]
+
+Truncation: keep all `D²d` singular values by default.  `χmax > 0` caps the
+internal bond; `cutoff > 0` discards `S[i] ≤ cutoff · S[1]`.  Singular
+values are distributed evenly between the two tensors (`A·√S` and `√S·B'`).
+
+Returns a NamedTuple `(A, B, S)`:
+
+* `A`: shape `(D, D, d, χ)` — index order `(extA1, extA2, σ_A, x_internal)`
+* `B`: shape `(χ, D, D, d)` — index order `(x_internal, extB1, extB2, σ_B)`
+* `S`: kept singular values (length `χ`)
+"""
+function split_honeycomb_merge(M::AbstractArray{T,5};
+                               convention::Symbol = :LU_RD,
+                               χmax::Int = 0,
+                               cutoff::Real = 0.0) where T
+    DL, DD, DR, DU, dphys = size(M)
+    DL == DD == DR == DU || throw(ArgumentError(
+        "All four virtual legs must have equal bond dimension, got sizes $(size(M)[1:4])"))
+    D = DL
+    d = isqrt(dphys)
+    d * d == dphys || throw(ArgumentError(
+        "Physical dimension $dphys is not a perfect square; cannot split as d⊗d"))
+
+    # Split physical leg: σ_A inner, σ_B outer (Julia column-major).
+    M6 = reshape(M, D, D, D, D, d, d)             # (L, D, R, U, σ_A, σ_B)
+
+    # Group legs into (A-side | B-side) according to the chosen convention.
+    if convention === :LU_RD
+        # A gets (L=1, U=4, σ_A=5);  B gets (R=3, D=2, σ_B=6)
+        M_perm = permutedims(M6, (1, 4, 5, 3, 2, 6))   # (L, U, σ_A | R, D, σ_B)
+    elseif convention === :LD_RU
+        # A gets (L=1, D=2, σ_A=5);  B gets (R=3, U=4, σ_B=6)
+        M_perm = permutedims(M6, (1, 2, 5, 3, 4, 6))   # (L, D, σ_A | R, U, σ_B)
+    else
+        throw(ArgumentError("convention must be :LU_RD or :LD_RU, got $(convention)"))
+    end
+
+    χfull = D * D * d
+    M_mat = reshape(M_perm, χfull, χfull)
+    U, S, V = svd(M_mat)
+
+    χ = χmax > 0 ? min(χmax, length(S)) : length(S)
+    if cutoff > 0
+        smax = first(S)
+        χcut = findlast(s -> s > cutoff * smax, S)
+        χ = min(χ, χcut === nothing ? 1 : χcut)
+    end
+
+    Sχ  = S[1:χ]
+    sqs = sqrt.(Sχ)
+    A_mat = U[:, 1:χ] * Diagonal(sqs)              # (D²d, χ)
+    B_mat = Diagonal(sqs) * V[:, 1:χ]'             # (χ, D²d)
+
+    A = reshape(A_mat, D, D, d, χ)
+    B = reshape(B_mat, χ, D, D, d)
+
+    return (A = A, B = B, S = Sχ)
+end

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -471,24 +471,24 @@
     # ================================================================
     @testset "split_honeycomb_merge SVD reverse" begin
         D, d = 3, 2
-        χfull = D * D * d
+        Dfull = D * D * d
 
         # --- :LU_RD convention: M = Σ_x A[L,U,σ_A,x] · B[x,R,D,σ_B] ---
-        A0 = randn(D, D, d, χfull)
-        B0 = randn(χfull, D, D, d)
+        A0 = randn(D, D, d, Dfull)
+        B0 = randn(Dfull, D, D, d)
         @tensor M6[L, Dn, R, U, sa, sb] := A0[L, U, sa, x] * B0[x, R, Dn, sb]
         M = reshape(M6, D, D, D, D, d^2)
 
         res = TeneT.split_honeycomb_merge(M; convention = :LU_RD)
-        @test size(res.A) == (D, D, d, χfull)
-        @test size(res.B) == (χfull, D, D, d)
-        @test length(res.S) == χfull
+        @test size(res.A) == (D, D, d, Dfull)
+        @test size(res.B) == (Dfull, D, D, d)
+        @test length(res.S) == Dfull
         @tensor Mr6[L, Dn, R, U, sa, sb] := res.A[L, U, sa, x] * res.B[x, R, Dn, sb]
         @test reshape(Mr6, D, D, D, D, d^2) ≈ M
 
         # --- :LD_RU convention: M = Σ_x A[L,D,σ_A,x] · B[x,R,U,σ_B] ---
-        A0 = randn(D, D, d, χfull)
-        B0 = randn(χfull, D, D, d)
+        A0 = randn(D, D, d, Dfull)
+        B0 = randn(Dfull, D, D, d)
         @tensor M6[L, Dn, R, U, sa, sb] := A0[L, Dn, sa, x] * B0[x, R, U, sb]
         M = reshape(M6, D, D, D, D, d^2)
 
@@ -496,8 +496,8 @@
         @tensor Mr6[L, Dn, R, U, sa, sb] := res.A[L, Dn, sa, x] * res.B[x, R, U, sb]
         @test reshape(Mr6, D, D, D, D, d^2) ≈ M
 
-        # --- truncation via χmax keeps exactly the requested bond ---
-        res_trunc = TeneT.split_honeycomb_merge(M; convention = :LD_RU, χmax = 5)
+        # --- truncation via Dtrunc keeps exactly the requested bond ---
+        res_trunc = TeneT.split_honeycomb_merge(M; convention = :LD_RU, Dtrunc = 5)
         @test size(res_trunc.A, 4) == 5
         @test size(res_trunc.B, 1) == 5
         @test length(res_trunc.S) == 5

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -466,4 +466,47 @@
         end
     end
 
+    # ================================================================
+    # split_honeycomb_merge — SVD roundtrip and shape checks
+    # ================================================================
+    @testset "split_honeycomb_merge SVD reverse" begin
+        D, d = 3, 2
+        χfull = D * D * d
+
+        # --- :LU_RD convention: M = Σ_x A[L,U,σ_A,x] · B[x,R,D,σ_B] ---
+        A0 = randn(D, D, d, χfull)
+        B0 = randn(χfull, D, D, d)
+        @tensor M6[L, Dn, R, U, sa, sb] := A0[L, U, sa, x] * B0[x, R, Dn, sb]
+        M = reshape(M6, D, D, D, D, d^2)
+
+        res = TeneT.split_honeycomb_merge(M; convention = :LU_RD)
+        @test size(res.A) == (D, D, d, χfull)
+        @test size(res.B) == (χfull, D, D, d)
+        @test length(res.S) == χfull
+        @tensor Mr6[L, Dn, R, U, sa, sb] := res.A[L, U, sa, x] * res.B[x, R, Dn, sb]
+        @test reshape(Mr6, D, D, D, D, d^2) ≈ M
+
+        # --- :LD_RU convention: M = Σ_x A[L,D,σ_A,x] · B[x,R,U,σ_B] ---
+        A0 = randn(D, D, d, χfull)
+        B0 = randn(χfull, D, D, d)
+        @tensor M6[L, Dn, R, U, sa, sb] := A0[L, Dn, sa, x] * B0[x, R, U, sb]
+        M = reshape(M6, D, D, D, D, d^2)
+
+        res = TeneT.split_honeycomb_merge(M; convention = :LD_RU)
+        @tensor Mr6[L, Dn, R, U, sa, sb] := res.A[L, Dn, sa, x] * res.B[x, R, U, sb]
+        @test reshape(Mr6, D, D, D, D, d^2) ≈ M
+
+        # --- truncation via χmax keeps exactly the requested bond ---
+        res_trunc = TeneT.split_honeycomb_merge(M; convention = :LD_RU, χmax = 5)
+        @test size(res_trunc.A, 4) == 5
+        @test size(res_trunc.B, 1) == 5
+        @test length(res_trunc.S) == 5
+        @test issorted(res_trunc.S; rev = true)
+
+        # --- argument validation ---
+        @test_throws ArgumentError TeneT.split_honeycomb_merge(randn(D, D, D, D, 3))   # 3 not a square
+        @test_throws ArgumentError TeneT.split_honeycomb_merge(randn(D, D + 1, D, D, d^2))
+        @test_throws ArgumentError TeneT.split_honeycomb_merge(M; convention = :bogus)
+    end
+
 end


### PR DESCRIPTION
## Summary

Add `split_honeycomb_merge(M; convention, χmax, cutoff)` in
`src/ipeps_optimize/build_A.jl` — the inverse of the Honeycomb sublattice
merge. Given a merged single-site iPEPS tensor `M` of shape
`(D, D, D, D, d²)`, it returns two sublattice tensors `A` and `B` with
three virtual legs and one physical leg each, joined by a new internal
virtual bond of dimension `χ ≤ D²·d` produced by a single SVD.

## Details

- Reshape physical leg `σ_AB` to `(σ_A, σ_B)` in Julia's column-major
  order (`σ_A` is the inner index).
- Permute legs into an `(A-side | B-side)` grouping selected by the
  `convention` keyword:
  - `:LU_RD` (default, "anti-diagonal" merge): A keeps `(L, U)`,
    B keeps `(R, D)`. Reconstruction
    `M[L,D,R,U,σ_AB] = Σ_x A[L,U,σ_A,x] · B[x,R,D,σ_B]`.
    This matches the natural u/v merge along the `a` bond in the
    brickwall convention (u with external `(L=c, U=b)`, v with
    external `(R=c, D=b)`).
  - `:LD_RU` ("diagonal" merge): A keeps `(L, D)`, B keeps `(R, U)`.
- SVD on the `(D²d × D²d)` matrix, distribute singular values evenly
  between A and B (`A·√S` and `√S·B'`).
- `χmax > 0` caps the bond; `cutoff > 0` discards `S[i] ≤ cutoff · S[1]`.

Returns a NamedTuple `(A, B, S)`:

- `A`: shape `(D, D, d, χ)` — `A[extA1, extA2, σ_A, x_internal]`
- `B`: shape `(χ, D, D, d)` — `B[x_internal, extB1, extB2, σ_B]`
- `S`: kept singular values (length `χ`)

## Test plan

Added a `@testset "split_honeycomb_merge SVD reverse"` block in
`test/test_ipeps.jl` that:

- [x] Builds random `A`, `B` with `χ = D²d`, contracts to form `M`, calls
      `split_honeycomb_merge`, and verifies `M_reconstructed ≈ M` for
      both `:LU_RD` and `:LD_RU` conventions.
- [x] Checks output shapes: `A` is `(D, D, d, D²d)`, `B` is `(D²d, D, D, d)`,
      `length(S) == D²d`.
- [x] Verifies `χmax = 5` keeps exactly 5 singular values (largest) and
      that the returned `S` is sorted in descending order.
- [x] Verifies `ArgumentError` is thrown for non-square physical dim,
      mismatched virtual bond dims, and unknown convention symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)