### PR TITLE
[codex] Add J1J2 honeycomb merge energy

### DIFF
--- a/examples/J1J2/J1J2_Honeycomb_merge_VUMPS_General.jl
+++ b/examples/J1J2/J1J2_Honeycomb_merge_VUMPS_General.jl
@@ -1,0 +1,78 @@
+using TeneT
+using Random
+using CUDA
+using OptimKit
+using LinearAlgebra
+using Zygote
+
+seed = 88
+Random.seed!(seed)
+atype = Array
+etype = Float64
+
+# Keep the default light enough to run through optimisation and observables.
+# Increase chi_list_opt and LBFGS maxiter for production scans.
+D, chi_init = 2, 16
+chi_list_opt = [chi_init]
+pattern = [1;;]
+# pattern = [1 2;
+#            2 1]
+# pattern = [1 3;
+#            2 4]
+
+# Honeycomb(:merge) stores two honeycomb physical sites in one square iPEPS
+# tensor with physical dimension d^2. The merge energy path currently supports
+# uniform couplings and no sublattice rotation.
+model = J1J2(lattice=Honeycomb(:merge),
+             S=0.5, J1=1.0, J2=0.5,
+             ifrotate=false,
+             couplingtype=:uniform, bondratio=1.0)
+No = 0
+SUtau = 0
+folder = joinpath(pkgdir(TeneT), "data/$model/$pattern/VUMPS_General/$etype/seed$seed/")
+boundary_alg = VUMPS{General}(ifupdown=true,
+                              ifdownfromup=false,
+                              ifsimple_eig=true,
+                              ifparallelupdown=false,
+                              ifparallel=false,
+                              forloop_iter=5,
+                              maxiter=30,
+                              miniter=0,
+                              maxiter_ad=4,
+                              miniter_ad=4,
+                              power_iter=5,
+                              power_iter_ad=5,
+                              power_iter_obs=40,
+                              show_every=10,
+                              tol=1e-10,
+                              verbosity=3,
+)
+params = GradientOptimize(model=model,
+                          pattern=pattern,
+                          boundary_alg=boundary_alg,
+                          optimizer=LBFGS(200; maxiter=1, verbosity=4, gradtol=1e-7, linesearch=HagerZhangLineSearch(maxfg=1)),
+                          forloop_iter=1,
+                          verbosity=4,
+                          folder=folder,
+                          ifSU=false,
+                          SUτ=SUtau,
+                          ifprecondition=true,
+                          iter_precond=0,
+                          reuse_env=true,
+                          ifsave_env=false,
+                          ifload_env=false,
+                          ifsave_lbfgs=false,
+                          ifload_lbfgs=false,
+                          ifplot=true
+)
+A = init_ipeps(;atype, etype, No, D, χ=chi_init, params)
+# A = init_ipeps_perturbation(;atype, No, D, D_new=3, χ=chi_init, ε=1e-2, params)
+# A = init_ipeps_SU(; atype, No, D, D_new=3, χ=chi_init, params)
+
+function restriction_ipeps(A)
+    A = local_min_norm(A, params)
+    return A
+end
+
+optimise_ipeps(A, chi_list_opt, params; restriction_ipeps)
+# observable(A, chi_init, params; restriction_ipeps)

--- a/src/models/J1J2/energy.jl
+++ b/src/models/J1J2/energy.jl
@@ -16,6 +16,115 @@ J1-J2 Heisenberg model with nearest-neighbor coupling `J1` and next-nearest-neig
                           # for Honeycomb{:brickwall_h}, bondratio<1 is plaquette, bondratio>1 is dimmer
 end
 
+"""
+    energy_value(model::J1J2{Honeycomb{:merge}}, A, env::VUMPSEnv, params)
+
+Two-site honeycomb merge geometry on an effective square lattice. Each square
+cell contains two honeycomb sublattice sites on one merged physical leg:
+`1(cell)-2(cell)` is the intra-cell J1 bond, while `2(cell)-1(right)` and
+`2(cell)-1(down)` are the inter-cell J1 bonds. Unlike J1J2p, J2 is placed on
+both triangular sublattices.
+"""
+function energy_value(model::J1J2{Honeycomb{:merge}}, A, env::VUMPSEnv, params::iPEPSOptimize)
+    model.ifrotate && throw(ArgumentError("J1J2{Honeycomb{:merge}} supports only ifrotate=false."))
+    @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
+    @unpack J2 = model
+
+    Ni, Nj = size(A)
+    len = length(A)
+    atype = _arraytype(A[1])
+    d = Int(2 * model.S + 1)
+    size(A[1], 5) == d^2 ||
+        throw(ArgumentError("Honeycomb{:merge} expects merged physical dimension d^2=$(d^2); got $(size(A[1], 5))."))
+
+    terms = _heisenberg_bond_terms(model, Array; ifrotate=false)
+    h_J1_onsite = _honeycomb_merge_onsite_op(terms, 1, 2, d, atype)
+    terms_J1_inter = _honeycomb_merge_intercell_terms(terms, 2, 1, d, atype)
+    terms_J2_1 = _honeycomb_merge_intercell_terms(terms, 1, 1, d, atype)
+    terms_J2_2 = _honeycomb_merge_intercell_terms(terms, 2, 2, d, atype)
+
+    e_dict = Dict{String, Dict{String, Any}}(
+        "bond_J1_onsite_energy" => Dict{String, Any}(),
+        "bond_J1H_energy"       => Dict{String, Any}(),
+        "bond_J1V_energy"       => Dict{String, Any}(),
+        "bond_J2H_energy"       => Dict{String, Any}(),
+        "bond_J2V_energy"       => Dict{String, Any}(),
+        "bond_J2/_energy"       => Dict{String, Any}()
+    )
+
+    etol = 0.0
+    for p in 1:len
+        i, j = Tuple(findfirst(==(p), A.pattern))
+        params.verbosity >= 4 && println("===========$i,$j===========")
+        J1o, J1h, J1v = enlarge_coupling(model, i, j)
+
+        # J1 onsite: sublattice 1 and 2 in the same merged cell.
+        ir = Ni + 1 - i
+        args11 = (FLo[i,j], ACu[i,j], A[i,j], ACd[ir,j], FRo[i,j])
+        e = _contract_one(contract_o_11, (args11..., h_J1_onsite), params)
+        n = _contract_one(contract_n_11, args11, params)
+        params.verbosity >= 4 && println("bond_J1_onsite = $(J1o * e/n)")
+        etol += J1o * e/n
+        e_dict["bond_J1_onsite_energy"]["$(i),$(j)"] = J1o * e/n
+
+        # Horizontal inter-cell bonds:
+        # J1H: 2(cell) - 1(right); J2H: same-sublattice bonds on 1 and 2.
+        ir = Ni + 1 - i
+        jr = mod1(j + 1, Nj)
+        args12 = (FLo[i,j], ACu[i,j], A[i,j], ACd[ir,j],
+                  FRo[i,jr], ARu[i,jr], A[i,jr], ARd[ir,jr])
+        n12 = _contract_one(contract_n_12, args12, params)
+
+        e = _contract_barebones(contract_o_12, args12, terms_J1_inter, params)
+        params.verbosity >= 4 && println("bond_J1H = $(J1h * e/n12)")
+        etol += J1h * e/n12
+        e_dict["bond_J1H_energy"]["$(i),$(j)"] = J1h * e/n12
+
+        e1 = _contract_barebones(contract_o_12, args12, terms_J2_1, params)
+        e2 = _contract_barebones(contract_o_12, args12, terms_J2_2, params)
+        params.verbosity >= 4 && println("bond_J2H = $(J2 * (e1 + e2)/n12)")
+        etol += J2 * (e1 + e2)/n12
+        e_dict["bond_J2H_energy"]["$(i),$(j)"] = J2 * (e1 + e2)/n12
+
+        # Vertical inter-cell bonds:
+        # J1V: 2(cell) - 1(down); J2V: same-sublattice bonds on 1 and 2.
+        ir = mod1(i + 1, Ni)
+        irr = mod1(Ni - i, Ni)
+        args21 = (ACu[i,j], FLu[i,j], A[i,j], FRu[i,j],
+                  FLo[ir,j], A[ir,j], FRo[ir,j], ACd[irr,j])
+        n21 = _contract_one(contract_n_21, args21, params)
+
+        e = _contract_barebones(contract_o_21, args21, terms_J1_inter, params)
+        params.verbosity >= 4 && println("bond_J1V = $(J1v * e/n21)")
+        etol += J1v * e/n21
+        e_dict["bond_J1V_energy"]["$(i),$(j)"] = J1v * e/n21
+
+        e1 = _contract_barebones(contract_o_21, args21, terms_J2_1, params)
+        e2 = _contract_barebones(contract_o_21, args21, terms_J2_2, params)
+        params.verbosity >= 4 && println("bond_J2V = $(J2 * (e1 + e2)/n21)")
+        etol += J2 * (e1 + e2)/n21
+        e_dict["bond_J2V_energy"]["$(i),$(j)"] = J2 * (e1 + e2)/n21
+
+        # Plaquette diagonals: 1(right)-1(down) and 2(right)-2(down).
+        ir = mod1(i + 1, Ni)
+        irr = mod1(Ni - i, Ni)
+        jr = mod1(j + 1, Nj)
+        args22 = (FLu[i,j], FLo[ir,j], ACu[i,j], ACd[irr,j],
+                  FRu[i,jr], FRo[ir,jr], ARu[i,jr], ARd[irr,jr],
+                  A[i,j], A[i,jr], A[ir,j], A[ir,jr])
+        e1 = _contract_barebones(contract_o_22_2, args22, terms_J2_1, params)
+        e2 = _contract_barebones(contract_o_22_2, args22, terms_J2_2, params)
+        n = _contract_one(contract_n_22, args22, params)
+        params.verbosity >= 4 && println("bond_J2/ = $(J2 * (e1 + e2)/n)")
+        etol += J2 * (e1 + e2)/n
+        e_dict["bond_J2/_energy"]["$(i),$(j)"] = J2 * (e1 + e2)/n
+    end
+
+    energy_per_site = etol / (2 * len)
+    params.verbosity >= 3 && println("energy per site = $energy_per_site")
+    return energy_per_site, e_dict
+end
+
 function energy_value(model::J1J2{Square}, A, env::VUMPSEnv, params::iPEPSOptimize)
     @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
     @unpack J1, J2 = model

--- a/src/models/J1J2/order_init.jl
+++ b/src/models/J1J2/order_init.jl
@@ -79,3 +79,15 @@ function enlarge_coupling(model::J1J2{Honeycomb{:brickwall_h}}, ::Val{:plaquette
 
     return J1h, J1v
 end
+
+function enlarge_coupling(model::J1J2{Honeycomb{:merge}}, ::Val{:uniform}, i, j)
+    J1 = model.J1
+    return J1, J1, J1
+end
+
+function enlarge_coupling(model::J1J2{Honeycomb{:merge}}, ::Val{:plaquette}, i, j)
+    throw(ArgumentError(
+        "J1J2{Honeycomb{:merge}} with couplingtype=:plaquette is not implemented. " *
+        "The two-site merge geometry currently supports only couplingtype=:uniform."
+    ))
+end

--- a/src/observable/magnetization.jl
+++ b/src/observable/magnetization.jl
@@ -333,7 +333,7 @@ function magnetization_value(model::Heisenberg{Kagome{:merge}}, A, env::VUMPSEnv
     return M_mean, m_dict
 end
 
-function magnetization_value(model::J1J2p{Honeycomb{:merge}}, A, env::VUMPSEnv, params)
+function magnetization_value(model::Union{J1J2{Honeycomb{:merge}}, J1J2p{Honeycomb{:merge}}}, A, env::VUMPSEnv, params)
     @unpack ACu, ARu, ACd, ARd, FLu, FRu, FLo, FRo = env
     @unpack ifparallel = params.boundary_alg
     @unpack forloop_iter = params

--- a/test/test_ipeps.jl
+++ b/test/test_ipeps.jl
@@ -350,6 +350,17 @@
         @test_throws ArgumentError TeneT.enlarge_coupling(m_plaq, 1, 1)
     end
 
+    @testset "enlarge_coupling J1J2 :merge" begin
+        m_unif = J1J2(lattice=Honeycomb{:merge}(), J1=1.5, J2=0.3,
+                      couplingtype=:uniform)
+        @test TeneT.enlarge_coupling(m_unif, 1, 1) == (1.5, 1.5, 1.5)
+        @test TeneT.enlarge_coupling(m_unif, 3, 2) == (1.5, 1.5, 1.5)
+
+        m_plaq = J1J2(lattice=Honeycomb{:merge}(), J1=1.0, J2=0.3,
+                      couplingtype=:plaquette, bondratio=0.5)
+        @test_throws ArgumentError TeneT.enlarge_coupling(m_plaq, 1, 1)
+    end
+
     @testset "energy_value J1J2p :merge smoke" begin
         using OptimKit: LBFGS
         using TeneT: ObsEnv, energy_value, build_A,
@@ -381,6 +392,72 @@
         A = build_A(A_raw, params)
 
         rt = initialize_env(A_raw, D, χ, params)
+        rt, _ = leading_boundary(rt, A, params.boundary_alg)
+        env = ObsEnv(rt, A, params.boundary_alg)
+
+        e, e_dict = energy_value(model, A, env, params)
+        @test isfinite(e)
+        @test haskey(e_dict, "bond_J1_onsite_energy")
+        @test haskey(e_dict, "bond_J1H_energy")
+        @test haskey(e_dict, "bond_J1V_energy")
+        @test haskey(e_dict, "bond_J2H_energy")
+        @test haskey(e_dict, "bond_J2V_energy")
+        @test haskey(e_dict, "bond_J2/_energy")
+        @test length(e_dict["bond_J1_onsite_energy"]) == length(unique(pattern))
+        @test length(e_dict["bond_J1H_energy"]) == length(unique(pattern))
+        @test length(e_dict["bond_J1V_energy"]) == length(unique(pattern))
+        @test length(e_dict["bond_J2H_energy"]) == length(unique(pattern))
+        @test length(e_dict["bond_J2V_energy"]) == length(unique(pattern))
+        @test length(e_dict["bond_J2/_energy"]) == length(unique(pattern))
+        for key in keys(e_dict)
+            for (_, v) in e_dict[key]
+                @test isfinite(v)
+            end
+        end
+
+        mag, m_dict = TeneT.magnetization_value(model, A, env, params)
+        @test isfinite(mag)
+        @test haskey(m_dict, "1,1,1")
+        @test haskey(m_dict, "1,1,2")
+        for key in ("1,1,1", "1,1,2")
+            @test isfinite(m_dict[key]["Mx"])
+            @test isfinite(m_dict[key]["My"])
+            @test isfinite(m_dict[key]["Mz"])
+            @test isfinite(m_dict[key]["|M|"])
+        end
+    end
+
+    @testset "energy_value J1J2 :merge smoke" begin
+        using OptimKit: LBFGS
+        using TeneT: ObsEnv, energy_value, build_A,
+                     leading_boundary, initialize_env, J1J2
+
+        Random.seed!(13)
+        D, chi = 2, 4
+        pattern = [1;;]
+        model = J1J2(lattice=Honeycomb{:merge}(),
+                     S=0.5, J1=1.0, J2=0.3,
+                     ifrotate=false,
+                     couplingtype=:uniform, bondratio=1.0)
+        folder = mktempdir()
+        boundary_alg = VUMPS{General}(ifupdown=true, ifsimple_eig=true,
+                                      maxiter=3, miniter=0,
+                                      maxiter_ad=1, miniter_ad=1,
+                                      tol=1e-3, verbosity=0, show_every=1000)
+        params = GradientOptimize(model=model, pattern=pattern,
+                                  boundary_alg=boundary_alg,
+                                  optimizer=LBFGS(10; maxiter=1, gradtol=1e-3, verbosity=0),
+                                  verbosity=0, folder=folder,
+                                  ifSU=false, SUτ=0.0, ifprecondition=false,
+                                  reuse_env=true, ifsave_env=false, ifload_env=false,
+                                  ifsave_lbfgs=false, ifload_lbfgs=false)
+
+        d, N = 2, 1
+        A_raw = (rand(Float64, D, D, D, D, d^2, N) .- 0.5)
+        A_raw /= norm(A_raw)
+        A = build_A(A_raw, params)
+
+        rt = initialize_env(A_raw, D, chi, params)
         rt, _ = leading_boundary(rt, A, params.boundary_alg)
         env = ObsEnv(rt, A, params.boundary_alg)
 


### PR DESCRIPTION
﻿## Summary

Adds `J1J2{Honeycomb{:merge}}` support following the existing `J1J2p{Honeycomb{:merge}}` implementation.

The new energy path keeps the same two-site merged honeycomb geometry:

- J1 onsite: `1(cell)-2(cell)`
- J1 horizontal/vertical: `2(cell)-1(right/down)`
- J2 horizontal/vertical/diagonal: same-sublattice bonds on both sublattices

The only model-level difference from `J1J2p` merge is that full `J1J2` adds the second triangular sublattice J2 terms via `terms_J2_2 = _honeycomb_merge_intercell_terms(terms, 2, 2, d, atype)` and sums them with the existing sublattice-1 contributions.

## Details

- Adds `energy_value(::J1J2{Honeycomb{:merge}}, ..., ::VUMPSEnv, ...)`.
- Adds uniform `enlarge_coupling` support for `J1J2{Honeycomb{:merge}}`; plaquette merge remains explicitly unsupported, matching `J1J2p` merge behavior.
- Reuses the `J1J2p` merge magnetization observable for `J1J2` because the merged physical layout is identical.
- Adds a merge example and focused smoke coverage.

## Validation

- `git diff --cached --check`
- Julia parse check for all touched files with `Meta.parseall`
- Focused Julia include/dispatch check confirming `J1J2{Honeycomb{:merge}}` defines `energy_value` and uniform `enlarge_coupling`

Full package load/test execution was not completed locally because dependency precompilation timed out in this environment.
